### PR TITLE
Named kernels

### DIFF
--- a/src/Kripke/Kernel/LPlusTimes.cpp
+++ b/src/Kripke/Kernel/LPlusTimes.cpp
@@ -41,6 +41,8 @@ using namespace Kripke::Core;
 
 struct LPlusTimesSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   void operator()(AL al, 
                   Kripke::SdomId sdom_id,
@@ -85,6 +87,7 @@ struct LPlusTimesSdom {
 
 };
 
+const std::string LPlusTimesSdom::KernelName =  "LPlusTimes";
 
 
 void Kripke::Kernel::LPlusTimes(Kripke::Core::DataStore &data_store)

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -45,6 +45,8 @@ using namespace Kripke::Core;
 
 struct LTimesSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   RAJA_INLINE
   void operator()(AL al, 
@@ -92,7 +94,7 @@ struct LTimesSdom {
 
 };
 
-
+const std::string LTimesSdom::KernelName = "LTimes";
 
 
 

--- a/src/Kripke/Kernel/Population.cpp
+++ b/src/Kripke/Kernel/Population.cpp
@@ -44,6 +44,8 @@ using namespace Kripke::Core;
 
 struct PopulationSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   void operator()(AL al, 
                   Kripke::SdomId sdom_id,
@@ -87,6 +89,8 @@ struct PopulationSdom {
   }
 
 };
+
+const std::string PopulationSdom::KernelName = "Population";
 
 
 /**

--- a/src/Kripke/Kernel/Scattering.cpp
+++ b/src/Kripke/Kernel/Scattering.cpp
@@ -48,6 +48,8 @@ using namespace Kripke::Core;
 
 struct ScatteringSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   RAJA_INLINE
   void operator()(AL al, 
@@ -124,6 +126,7 @@ struct ScatteringSdom {
 
 };
 
+const std::string ScatteringSdom::KernelName = "Scattering";
 
 
 /**

--- a/src/Kripke/Kernel/Source.cpp
+++ b/src/Kripke/Kernel/Source.cpp
@@ -48,6 +48,8 @@ using namespace Kripke::Core;
  */
 struct SourceSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   RAJA_INLINE
   void operator()(AL al, 
@@ -100,6 +102,7 @@ struct SourceSdom {
   }
 };
 
+const std::string SourceSdom::KernelName = "Source";
 
 
 void Kripke::Kernel::source(DataStore &data_store)

--- a/src/Kripke/Kernel/SweepSubdomain.cpp
+++ b/src/Kripke/Kernel/SweepSubdomain.cpp
@@ -44,6 +44,8 @@ using namespace Kripke::Core;
 
 struct SweepSdom {
 
+  static const std::string KernelName;
+
   template<typename AL>
   RAJA_INLINE
   void operator()(AL al, Kripke::Core::DataStore &data_store,
@@ -131,6 +133,8 @@ struct SweepSdom {
     );
   }
 };
+
+const std::string SweepSdom::KernelName = "sweepSubdomain";
 
 void Kripke::Kernel::sweepSubdomain(Kripke::Core::DataStore &data_store,
     Kripke::SdomId sdom_id)


### PR DESCRIPTION
It would be helpful to a lot of tools work to be able to name the kernels. This gives each kernel a name, such that a tool could extract it in dispatch.