### PR TITLE
[DNM] Clang Jit Prototype

### DIFF
--- a/src/Kripke/Core/DataStore.cpp
+++ b/src/Kripke/Core/DataStore.cpp
@@ -21,7 +21,7 @@ void DataStore::addVariable(std::string const &name,
   Kripke::Core::BaseVar *var)
 {
   if(m_vars.find(name) != m_vars.end()){
-    throw std::domain_error("Variable '" + name + "' already exists");
+    //throw std::domain_error("Variable '" + name + "' already exists");
   }
 
   m_vars[name] = var;
@@ -33,7 +33,7 @@ void DataStore::addVariable(std::string const &name,
 void DataStore::deleteVariable(std::string const &name){
   auto it = m_vars.find(name);
   if(it == m_vars.end()){
-    throw std::domain_error("Variable '" + name + "' does not exist");
+    //throw std::domain_error("Variable '" + name + "' does not exist");
   }
 
   // destroy object

--- a/src/Kripke/Core/DataStore.h
+++ b/src/Kripke/Core/DataStore.h
@@ -71,7 +71,7 @@ class DataStore {
       // Perform lookup by name
       auto it = m_vars.find(name);
       if(it == m_vars.end()){
-        throw std::domain_error("Cannot find '" + name + "' in DataStore");
+        //throw std::domain_error("Cannot find '" + name + "' in DataStore");
       }
 
       // Cast from BaseVar* and check for correctness

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -46,6 +46,8 @@ namespace Kripke {
 
     void LTimes(Kripke::Core::DataStore &data_store);
 
+    template<typename AL>
+    [[clang::jit]] void LTimesJit(Kripke::Core::DataStore &data_store);
 
     double population(Kripke::Core::DataStore &data_store);
 

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -41,7 +41,7 @@
 #include <Kripke/Kernel.h>
 #include <Kripke/Timing.h>
 #include <Kripke/VarTypes.h>
-
+#include <Kripke/Arch/LTimes.h>
 
 namespace Kripke {
 
@@ -51,7 +51,7 @@ namespace Kripke {
 
 
     void LTimes(Kripke::Core::DataStore &data_store);
-
+    
     template<typename AL>
     [[clang::jit]] void LTimesJit(Kripke::Core::DataStore &data_store){
         using namespace Kripke;

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -36,7 +36,10 @@
 #include <Kripke.h>
 #include <Kripke/Core/DataStore.h>
 #include <utility>
+#include <Kripke/Arch/Scattering.h>
+#include <Kripke/Arch/Source.h>
 #include <Kripke/Arch/LTimes.h>
+#include <Kripke/Arch/LPlusTimes.h>
 #include <Kripke/Core/VarLayout.h>
 #include <Kripke/Kernel.h>
 #include <Kripke/Timing.h>
@@ -47,15 +50,65 @@ namespace Kripke {
 
   namespace Kernel {
 
-    void LPlusTimes(Kripke::Core::DataStore &data_store);
+    using namespace Kripke;
+    using namespace Kripke::Core;
+    template<typename AL>
+    [[clang::jit]] void LPlusTimes(Kripke::Core::DataStore &data_store){
+      KRIPKE_TIMER(data_store, LPlusTimes);
+
+      Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+      Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+      Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+      Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+
+      auto &field_phi_out =   data_store.getVariable<Field_Moments>("phi_out");
+      auto &field_rhs =       data_store.getVariable<Field_Flux>("rhs");
+      auto &field_ell_plus =  data_store.getVariable<Field_EllPlus>("ell_plus");
+
+      ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+
+      // Loop over Subdomains
+      for (Kripke::SdomId sdom_id : field_rhs.getWorkList()){
+    
+        using ExecPolicy = typename Kripke::Arch::Policy_LPlusTimes<AL>::ExecPolicy;
+
+        auto sdom_al = getSdomAL(AL(), sdom_id);
+
+    // Get dimensioning
+    int num_directions = set_dir.size(sdom_id);
+    int num_groups =     set_group.size(sdom_id);
+    int num_moments =    set_moment.size(sdom_id);
+    int num_zones =      set_zone.size(sdom_id);
+
+    // Get views
+    auto phi_out  = sdom_al.getView(field_phi_out);
+    auto rhs      = sdom_al.getView(field_rhs);
+    auto ell_plus = sdom_al.getView(field_ell_plus); 
+
+    // Compute:  rhs =  ell_plus * phi_out
+    RAJA::kernel<ExecPolicy>(
+        camp::make_tuple(
+            RAJA::TypedRangeSegment<Direction>(0, num_directions),
+            RAJA::TypedRangeSegment<Moment>(0, num_moments),
+            RAJA::TypedRangeSegment<Group>(0, num_groups),
+            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+        KRIPKE_LAMBDA (Direction d, Moment nm, Group g, Zone z) {
+
+            rhs(d,g,z) += ell_plus(d, nm) * phi_out(nm, g, z);
+
+        }
+    );
 
 
-    void LTimes(Kripke::Core::DataStore &data_store);
+      }
+
+    }
+
+
+    //void LTimes(Kripke::Core::DataStore &data_store);
     
     template<typename AL>
-    [[clang::jit]] void LTimesJit(Kripke::Core::DataStore &data_store){
-        using namespace Kripke;
-        using namespace Kripke::Core;
+    [[clang::jit]] void LTimes(Kripke::Core::DataStore &data_store){
         KRIPKE_TIMER(data_store, LTimes);
 
         using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
@@ -99,22 +152,175 @@ namespace Kripke {
               }
           );
 
-          //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
-          //                 set_dir, set_group, set_zone, set_moment,
-          //                 field_psi, field_phi, field_ell);
-
-
         }
 
     }
 
     double population(Kripke::Core::DataStore &data_store);
 
+    template<typename AL>
+    [[clang::jit]] void scattering(Kripke::Core::DataStore &data_store){
+  KRIPKE_TIMER(data_store, Scattering);
 
-    void scattering(Kripke::Core::DataStore &data_store);
+  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+
+  auto &pspace = data_store.getVariable<Kripke::Core::PartitionSpace>("pspace");
+
+  auto &set_group  = data_store.getVariable<Kripke::Core::Set>("Set/Group");
+  auto &set_moment = data_store.getVariable<Kripke::Core::Set>("Set/Moment");
+  auto &set_zone   = data_store.getVariable<Kripke::Core::Set>("Set/Zone");
+
+  auto &field_phi     = data_store.getVariable<Kripke::Field_Moments>("phi");
+  auto &field_phi_out = data_store.getVariable<Kripke::Field_Moments>("phi_out");
+  auto &field_sigs    = data_store.getVariable<Field_SigmaS>("data/sigs");
+
+  auto &field_zone_to_mixelem     = data_store.getVariable<Field_Zone2MixElem>("zone_to_mixelem");
+  auto &field_zone_to_num_mixelem = data_store.getVariable<Field_Zone2Int>("zone_to_num_mixelem");
+  auto &field_mixed_to_material = data_store.getVariable<Field_MixElem2Material>("mixelem_to_material");
+  auto &field_mixed_to_fraction = data_store.getVariable<Field_MixElem2Double>("mixelem_to_fraction");
+
+  auto &field_moment_to_legendre = data_store.getVariable<Field_Moment2Legendre>("moment_to_legendre");
 
 
-    void source(Kripke::Core::DataStore &data_store);
+  // Loop over subdomains and compute scattering source
+  for(auto sdom_src : field_phi.getWorkList()){
+    for(auto sdom_dst : field_phi_out.getWorkList()){
+
+      // Only work on subdomains where src and dst are on the same R subdomain
+      size_t r_src = pspace.subdomainToSpace(SPACE_R, sdom_src);
+      size_t r_dst = pspace.subdomainToSpace(SPACE_R, sdom_dst);
+      if(r_src != r_dst){
+        continue;
+      }
+
+
+    using ExecPolicy = typename Kripke::Arch::Policy_Scattering<AL>::ExecPolicy;
+
+    auto sdom_al = getSdomAL(AL(), sdom_src);
+
+    // Get glower for src and dst ranges (to index into sigma_s)
+    int glower_src = set_group.lower(sdom_src);
+    int glower_dst = set_group.lower(sdom_dst);
+
+
+    // get material mix information
+    auto moment_to_legendre = sdom_al.getView(field_moment_to_legendre);
+
+    auto phi     = sdom_al.getView(field_phi);
+    auto phi_out = sdom_al.getView(field_phi_out, sdom_dst);
+    auto sigs    = sdom_al.getView(field_sigs);
+    
+    auto zone_to_mixelem     = sdom_al.getView(field_zone_to_mixelem);
+    auto zone_to_num_mixelem = sdom_al.getView(field_zone_to_num_mixelem);
+    auto mixelem_to_material = sdom_al.getView(field_mixed_to_material);
+    auto mixelem_to_fraction = sdom_al.getView(field_mixed_to_fraction);
+    
+    // grab dimensions
+    int num_zones =      set_zone.size(sdom_src);
+    int num_groups_src = set_group.size(sdom_src);
+    int num_groups_dst = set_group.size(sdom_dst);
+    int num_moments =    set_moment.size(sdom_dst);
+
+    RAJA::kernel<ExecPolicy>(
+        camp::make_tuple(
+            RAJA::TypedRangeSegment<Moment>(0, num_moments),
+            RAJA::TypedRangeSegment<Group>(0, num_groups_dst),
+            RAJA::TypedRangeSegment<Group>(0, num_groups_src),
+            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+        KRIPKE_LAMBDA (Moment nm, Group g, Group gp, Zone z) {
+
+            // map nm to n
+            Legendre n = moment_to_legendre(nm);
+
+            GlobalGroup global_g{*g+glower_dst};
+            GlobalGroup global_gp{*gp+glower_src};
+
+            MixElem mix_start = zone_to_mixelem(z);
+            MixElem mix_stop = mix_start + zone_to_num_mixelem(z);
+
+            double sigs_z = 0.0;
+            for(MixElem mix = mix_start;mix < mix_stop;++ mix){
+              Material mat = mixelem_to_material(mix);
+              double fraction = mixelem_to_fraction(mix);
+
+              sigs_z += sigs(mat, n, global_g, global_gp) * fraction;
+            }
+            phi_out(nm, g, z) += sigs_z * phi(nm, gp, z);
+        }
+    );
+
+
+
+    }
+
+  }
+
+
+    }
+
+  template<typename AL>
+  [[clang::jit]]  void source(Kripke::Core::DataStore &data_store){
+  KRIPKE_TIMER(data_store, Source);
+
+  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+
+  auto &set_group   = data_store.getVariable<Set>("Set/Group");
+  auto &set_mixelem = data_store.getVariable<Set>("Set/MixElem");
+
+  auto &field_phi_out = data_store.getVariable<Kripke::Field_Moments>("phi_out");
+
+  auto &field_mixed_to_zone     = data_store.getVariable<Field_MixElem2Zone>("mixelem_to_zone");
+  auto &field_mixed_to_material = data_store.getVariable<Field_MixElem2Material>("mixelem_to_material");
+  auto &field_mixed_to_fraction = data_store.getVariable<Field_MixElem2Double>("mixelem_to_fraction");
+
+  double source_strength = 1.0;
+
+
+  // Loop over zoneset subdomains
+  for(auto sdom_id : field_phi_out.getWorkList()){
+
+
+    using ExecPolicy = typename Kripke::Arch::Policy_Source<AL>::ExecPolicy;
+
+    auto sdom_al = getSdomAL(AL(), sdom_id);
+
+    // Source term is isotropic
+    Moment nm{0};
+
+    auto phi_out = sdom_al.getView(field_phi_out);
+
+    auto mixelem_to_zone     = sdom_al.getView(field_mixed_to_zone);
+    auto mixelem_to_material = sdom_al.getView(field_mixed_to_material);
+    auto mixelem_to_fraction = sdom_al.getView(field_mixed_to_fraction);
+
+    int num_mixed  = set_mixelem.size(sdom_id);
+    int num_groups = set_group.size(sdom_id);
+
+
+    // Compute:  phi =  ell * psi
+    RAJA::kernel<ExecPolicy>(
+        camp::make_tuple(
+            RAJA::TypedRangeSegment<Group>(0, num_groups),
+            RAJA::TypedRangeSegment<MixElem>(0, num_mixed) ),
+        KRIPKE_LAMBDA (Group g, MixElem mix) {
+
+            Material material = mixelem_to_material(mix);
+
+            if(material == 2){
+              Zone z = mixelem_to_zone(mix);
+              double fraction = mixelem_to_fraction(mix);
+
+              phi_out(nm, g, z) += source_strength * fraction;
+            }
+
+        }
+    );
+
+
+  }
+
+
+    }
 
 
     void sweepSubdomain(Kripke::Core::DataStore &data_store, Kripke::SdomId sdom_id);

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -36,6 +36,12 @@
 #include <Kripke.h>
 #include <Kripke/Core/DataStore.h>
 #include <utility>
+#include <Kripke/Arch/LTimes.h>
+#include <Kripke/Core/VarLayout.h>
+#include <Kripke/Kernel.h>
+#include <Kripke/Timing.h>
+#include <Kripke/VarTypes.h>
+
 
 namespace Kripke {
 
@@ -47,7 +53,60 @@ namespace Kripke {
     void LTimes(Kripke::Core::DataStore &data_store);
 
     template<typename AL>
-    [[clang::jit]] void LTimesJit(Kripke::Core::DataStore &data_store);
+    [[clang::jit]] void LTimesJit(Kripke::Core::DataStore &data_store){
+        using namespace Kripke;
+        using namespace Kripke::Core;
+        KRIPKE_TIMER(data_store, LTimes);
+
+        using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
+
+        Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+        Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+        Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+        Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+
+        auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
+        auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
+        auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
+
+        // Loop over Subdomains
+        for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
+
+          auto sdom_al = getSdomAL(AL(), sdom_id);
+ 
+          // Get dimensioning
+          int num_directions = set_dir.size(sdom_id);
+          int num_groups =     set_group.size(sdom_id);
+          int num_moments =    set_moment.size(sdom_id);
+          int num_zones =      set_zone.size(sdom_id);
+
+          // Get pointers
+          auto psi = sdom_al.getView(field_psi);
+          auto phi = sdom_al.getView(field_phi);
+          auto ell = sdom_al.getView(field_ell);
+
+          // Compute:  phi =  ell * psi
+          RAJA::kernel<ExecPolicy>(
+              camp::make_tuple(
+                  RAJA::TypedRangeSegment<Moment>(0, num_moments),
+                  RAJA::TypedRangeSegment<Direction>(0, num_directions),
+                  RAJA::TypedRangeSegment<Group>(0, num_groups),
+                  RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+              KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
+
+                 phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
+
+              }
+          );
+
+          //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
+          //                 set_dir, set_group, set_zone, set_moment,
+          //                 field_psi, field_phi, field_ell);
+
+
+        }
+
+    }
 
     double population(Kripke::Core::DataStore &data_store);
 

--- a/src/Kripke/Kernel/LPlusTimes.cpp
+++ b/src/Kripke/Kernel/LPlusTimes.cpp
@@ -87,28 +87,28 @@ struct LPlusTimesSdom {
 
 
 
-void Kripke::Kernel::LPlusTimes(Kripke::Core::DataStore &data_store)
-{
-  KRIPKE_TIMER(data_store, LPlusTimes);
-
-  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
-  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
-  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
-  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
-
-  auto &field_phi_out =   data_store.getVariable<Field_Moments>("phi_out");
-  auto &field_rhs =       data_store.getVariable<Field_Flux>("rhs");
-  auto &field_ell_plus =  data_store.getVariable<Field_EllPlus>("ell_plus");
-
-  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
-
-  // Loop over Subdomains
-  for (Kripke::SdomId sdom_id : field_rhs.getWorkList()){
-
-    Kripke::dispatch(al_v, LPlusTimesSdom{}, sdom_id,
-                     set_dir, set_group, set_zone, set_moment,
-                     field_phi_out, field_rhs, field_ell_plus);
-
-  }
-
-}
+//void Kripke::Kernel::LPlusTimes(Kripke::Core::DataStore &data_store)
+//{
+//  KRIPKE_TIMER(data_store, LPlusTimes);
+//
+//  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+//  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+//  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+//  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+//
+//  auto &field_phi_out =   data_store.getVariable<Field_Moments>("phi_out");
+//  auto &field_rhs =       data_store.getVariable<Field_Flux>("rhs");
+//  auto &field_ell_plus =  data_store.getVariable<Field_EllPlus>("ell_plus");
+//
+//  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+//
+//  // Loop over Subdomains
+//  for (Kripke::SdomId sdom_id : field_rhs.getWorkList()){
+//
+//    Kripke::dispatch(al_v, LPlusTimesSdom{}, sdom_id,
+//                     set_dir, set_group, set_zone, set_moment,
+//                     field_phi_out, field_rhs, field_ell_plus);
+//
+//  }
+//
+//}

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -93,11 +93,60 @@ struct LTimesSdom {
 };
 
 
+template<typename AL>
+[[clang::jit]] void Kripke::Kernel::LTimesJit(Kripke::Core::DataStore &data_store)
+{
+  KRIPKE_TIMER(data_store, LTimes);
+
+  using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
+
+  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+
+  auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
+  auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
+  auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
+
+  // Loop over Subdomains
+  for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
+
+    auto sdom_al = getSdomAL(AL(), sdom_id);
+ 
+    // Get dimensioning
+    int num_directions = set_dir.size(sdom_id);
+    int num_groups =     set_group.size(sdom_id);
+    int num_moments =    set_moment.size(sdom_id);
+    int num_zones =      set_zone.size(sdom_id);
+
+    // Get pointers
+    auto psi = sdom_al.getView(field_psi);
+    auto phi = sdom_al.getView(field_phi);
+    auto ell = sdom_al.getView(field_ell);
+
+    // Compute:  phi =  ell * psi
+    RAJA::kernel<ExecPolicy>(
+        camp::make_tuple(
+            RAJA::TypedRangeSegment<Moment>(0, num_moments),
+            RAJA::TypedRangeSegment<Direction>(0, num_directions),
+            RAJA::TypedRangeSegment<Group>(0, num_groups),
+            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+        KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
+
+           phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
+
+        }
+    );
+
+    //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
+    //                 set_dir, set_group, set_zone, set_moment,
+    //                 field_psi, field_phi, field_ell);
 
 
+  }
 
-
-
+}
 
 void Kripke::Kernel::LTimes(Kripke::Core::DataStore &data_store)
 {
@@ -117,14 +166,10 @@ void Kripke::Kernel::LTimes(Kripke::Core::DataStore &data_store)
   // Loop over Subdomains
   for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
 
-
     Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
                      set_dir, set_group, set_zone, set_moment,
                      field_psi, field_phi, field_ell);
 
-
   }
 
 }
-
-

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -93,60 +93,60 @@ struct LTimesSdom {
 };
 
 
-template<typename AL>
-[[clang::jit]] void Kripke::Kernel::LTimesJit(Kripke::Core::DataStore &data_store)
-{
-  KRIPKE_TIMER(data_store, LTimes);
-
-  using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
-
-  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
-  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
-  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
-  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
-
-  auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
-  auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
-  auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
-
-  // Loop over Subdomains
-  for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
-
-    auto sdom_al = getSdomAL(AL(), sdom_id);
- 
-    // Get dimensioning
-    int num_directions = set_dir.size(sdom_id);
-    int num_groups =     set_group.size(sdom_id);
-    int num_moments =    set_moment.size(sdom_id);
-    int num_zones =      set_zone.size(sdom_id);
-
-    // Get pointers
-    auto psi = sdom_al.getView(field_psi);
-    auto phi = sdom_al.getView(field_phi);
-    auto ell = sdom_al.getView(field_ell);
-
-    // Compute:  phi =  ell * psi
-    RAJA::kernel<ExecPolicy>(
-        camp::make_tuple(
-            RAJA::TypedRangeSegment<Moment>(0, num_moments),
-            RAJA::TypedRangeSegment<Direction>(0, num_directions),
-            RAJA::TypedRangeSegment<Group>(0, num_groups),
-            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
-        KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
-
-           phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
-
-        }
-    );
-
-    //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
-    //                 set_dir, set_group, set_zone, set_moment,
-    //                 field_psi, field_phi, field_ell);
-
-
-  }
-
-}
+//template<typename AL>
+//[[clang::jit]] void Kripke::Kernel::LTimesJit(Kripke::Core::DataStore &data_store)
+//{
+//  KRIPKE_TIMER(data_store, LTimes);
+//
+//  using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
+//
+//  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+//  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+//  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+//  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+//
+//  auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
+//  auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
+//  auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
+//
+//  // Loop over Subdomains
+//  for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
+//
+//    auto sdom_al = getSdomAL(AL(), sdom_id);
+// 
+//    // Get dimensioning
+//    int num_directions = set_dir.size(sdom_id);
+//    int num_groups =     set_group.size(sdom_id);
+//    int num_moments =    set_moment.size(sdom_id);
+//    int num_zones =      set_zone.size(sdom_id);
+//
+//    // Get pointers
+//    auto psi = sdom_al.getView(field_psi);
+//    auto phi = sdom_al.getView(field_phi);
+//    auto ell = sdom_al.getView(field_ell);
+//
+//    // Compute:  phi =  ell * psi
+//    RAJA::kernel<ExecPolicy>(
+//        camp::make_tuple(
+//            RAJA::TypedRangeSegment<Moment>(0, num_moments),
+//            RAJA::TypedRangeSegment<Direction>(0, num_directions),
+//            RAJA::TypedRangeSegment<Group>(0, num_groups),
+//            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+//        KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
+//
+//           phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
+//
+//        }
+//    );
+//
+//    //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
+//    //                 set_dir, set_group, set_zone, set_moment,
+//    //                 field_psi, field_phi, field_ell);
+//
+//
+//  }
+//
+//}
 
 void Kripke::Kernel::LTimes(Kripke::Core::DataStore &data_store)
 {

--- a/src/Kripke/Kernel/LTimesTakeOne.cpp
+++ b/src/Kripke/Kernel/LTimesTakeOne.cpp
@@ -93,58 +93,75 @@ struct LTimesSdom {
 };
 
 
-//template<typename AL>
-//[[clang::jit]] void Kripke::Kernel::LTimesJit(Kripke::Core::DataStore &data_store)
-//{
-//  KRIPKE_TIMER(data_store, LTimes);
-//
-//  using ExecPolicy = typename Kripke::Arch::Policy_LTimes<AL>::ExecPolicy;
-//
-//  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
-//  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
-//  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
-//  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
-//
-//  auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
-//  auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
-//  auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
-//
-//  // Loop over Subdomains
-//  for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
-//
-//    auto sdom_al = getSdomAL(AL(), sdom_id);
-// 
-//    // Get dimensioning
-//    int num_directions = set_dir.size(sdom_id);
-//    int num_groups =     set_group.size(sdom_id);
-//    int num_moments =    set_moment.size(sdom_id);
-//    int num_zones =      set_zone.size(sdom_id);
-//
-//    // Get pointers
-//    auto psi = sdom_al.getView(field_psi);
-//    auto phi = sdom_al.getView(field_phi);
-//    auto ell = sdom_al.getView(field_ell);
-//
-//    // Compute:  phi =  ell * psi
-//    RAJA::kernel<ExecPolicy>(
-//        camp::make_tuple(
-//            RAJA::TypedRangeSegment<Moment>(0, num_moments),
-//            RAJA::TypedRangeSegment<Direction>(0, num_directions),
-//            RAJA::TypedRangeSegment<Group>(0, num_groups),
-//            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
-//        KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
-//
-//           phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
-//
-//        }
-//    );
-//
-//    //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
-//    //                 set_dir, set_group, set_zone, set_moment,
-//    //                 field_psi, field_phi, field_ell);
-//
-//
-//  }
-//
-//}
+template<typename Architecture,typename... Args >
+auto viewer(Args... args);
+
+template<typename Architecture, typename Arg, typename Args...>
+auto viewer<Architecture, Arg, Args...>(Arg arg, Args... args){
+  return std::tuple_cat
+}
+
+template<typename ExecPolicy, typename TupleLike, typename Executableish>
+[[clang::jit]] void labrador(TupleLike&& tuple, Executableish&& exec){
+  RAJA::kernel<ExecPolicy>(
+      std::forward<TupleLike>(tuple),
+      std::forward<Executableish>(exec)
+  );
+}
+
+void Kripke::Kernel::LTimes(Kripke::Core::DataStore &data_store)
+{
+  KRIPKE_TIMER(data_store, LTimes);
+
+  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+
+  Set const &set_dir    = data_store.getVariable<Set>("Set/Direction");
+  Set const &set_group  = data_store.getVariable<Set>("Set/Group");
+  Set const &set_zone   = data_store.getVariable<Set>("Set/Zone");
+  Set const &set_moment = data_store.getVariable<Set>("Set/Moment");
+
+  auto &field_psi =       data_store.getVariable<Field_Flux>("psi");
+  auto &field_phi =       data_store.getVariable<Field_Moments>("phi");
+  auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
+
+
+  auto sdom_al = getSdomAL(al, sdom_id);
+  using ExecPolicy = typename Kripke::Arch::Policy_LTimes<decltype(sdom_al)>::ExecPolicy;
+ 
+  // Get dimensioning
+  int num_directions = set_dir.size(sdom_id);
+  int num_groups =     set_group.size(sdom_id);
+  int num_moments =    set_moment.size(sdom_id);
+  int num_zones =      set_zone.size(sdom_id);
+
+  // Get pointers
+  auto psi = sdom_al.getView(field_psi);
+  auto phi = sdom_al.getView(field_phi);
+  auto ell = sdom_al.getView(field_ell);
+
+  // Loop over Subdomains
+  for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
+
+    labrador<"ExecPolicy">(
+        camp::make_tuple(
+            RAJA::TypedRangeSegment<Moment>(0, num_moments),
+            RAJA::TypedRangeSegment<Direction>(0, num_directions),
+            RAJA::TypedRangeSegment<Group>(0, num_groups),
+            RAJA::TypedRangeSegment<Zone>(0, num_zones) ),
+        KRIPKE_LAMBDA (Moment nm, Direction d, Group g, Zone z) {
+
+           phi(nm,g,z) += ell(nm, d) * psi(d, g, z);
+
+        }
+    );
+
+    //Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
+    //                 set_dir, set_group, set_zone, set_moment,
+    //                 field_psi, field_phi, field_ell);
+
+
+  }
+
+}
+
 

--- a/src/Kripke/Kernel/Scattering.cpp
+++ b/src/Kripke/Kernel/Scattering.cpp
@@ -131,58 +131,5 @@ struct ScatteringSdom {
   phi_out(gp,z,nm) = sum_g { sigs(g, n, gp) * phi(g,z,nm) }
 */
 
-void Kripke::Kernel::scattering(Kripke::Core::DataStore &data_store)
-{
-  KRIPKE_TIMER(data_store, Scattering);
-
-  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
-
-  auto &pspace = data_store.getVariable<Kripke::Core::PartitionSpace>("pspace");
-
-  auto &set_group  = data_store.getVariable<Kripke::Core::Set>("Set/Group");
-  auto &set_moment = data_store.getVariable<Kripke::Core::Set>("Set/Moment");
-  auto &set_zone   = data_store.getVariable<Kripke::Core::Set>("Set/Zone");
-
-  auto &field_phi     = data_store.getVariable<Kripke::Field_Moments>("phi");
-  auto &field_phi_out = data_store.getVariable<Kripke::Field_Moments>("phi_out");
-  auto &field_sigs    = data_store.getVariable<Field_SigmaS>("data/sigs");
-
-  auto &field_zone_to_mixelem     = data_store.getVariable<Field_Zone2MixElem>("zone_to_mixelem");
-  auto &field_zone_to_num_mixelem = data_store.getVariable<Field_Zone2Int>("zone_to_num_mixelem");
-  auto &field_mixed_to_material = data_store.getVariable<Field_MixElem2Material>("mixelem_to_material");
-  auto &field_mixed_to_fraction = data_store.getVariable<Field_MixElem2Double>("mixelem_to_fraction");
-
-  auto &field_moment_to_legendre = data_store.getVariable<Field_Moment2Legendre>("moment_to_legendre");
-
-
-  // Loop over subdomains and compute scattering source
-  for(auto sdom_src : field_phi.getWorkList()){
-    for(auto sdom_dst : field_phi_out.getWorkList()){
-
-      // Only work on subdomains where src and dst are on the same R subdomain
-      size_t r_src = pspace.subdomainToSpace(SPACE_R, sdom_src);
-      size_t r_dst = pspace.subdomainToSpace(SPACE_R, sdom_dst);
-      if(r_src != r_dst){
-        continue;
-      }
-
-      Kripke::dispatch(al_v, ScatteringSdom{}, sdom_src,
-                       sdom_dst,
-                       set_group, set_zone, set_moment,
-                       field_phi, field_phi_out, field_sigs,
-                       field_zone_to_mixelem,
-                       field_zone_to_num_mixelem,
-                       field_mixed_to_material,
-                       field_mixed_to_fraction,
-                       field_moment_to_legendre);
-
-
-
-    }
-
-  }
-
-
-}
 
 

--- a/src/Kripke/Kernel/Source.cpp
+++ b/src/Kripke/Kernel/Source.cpp
@@ -102,36 +102,36 @@ struct SourceSdom {
 
 
 
-void Kripke::Kernel::source(DataStore &data_store)
-{
-  KRIPKE_TIMER(data_store, Source);
-
-  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
-
-  auto &set_group   = data_store.getVariable<Set>("Set/Group");
-  auto &set_mixelem = data_store.getVariable<Set>("Set/MixElem");
-
-  auto &field_phi_out = data_store.getVariable<Kripke::Field_Moments>("phi_out");
-
-  auto &field_mixed_to_zone     = data_store.getVariable<Field_MixElem2Zone>("mixelem_to_zone");
-  auto &field_mixed_to_material = data_store.getVariable<Field_MixElem2Material>("mixelem_to_material");
-  auto &field_mixed_to_fraction = data_store.getVariable<Field_MixElem2Double>("mixelem_to_fraction");
-
-  double source_strength = 1.0;
-
-
-  // Loop over zoneset subdomains
-  for(auto sdom_id : field_phi_out.getWorkList()){
-
-    Kripke::dispatch(al_v, SourceSdom{}, sdom_id,
-                     set_group, set_mixelem,
-                     field_phi_out,
-                     field_mixed_to_zone,
-                     field_mixed_to_material,
-                     field_mixed_to_fraction,
-                     source_strength);
-
-  }
-
-
-}
+//void Kripke::Kernel::source(DataStore &data_store)
+//{
+//  KRIPKE_TIMER(data_store, Source);
+//
+//  ArchLayoutV al_v = data_store.getVariable<ArchLayout>("al").al_v;
+//
+//  auto &set_group   = data_store.getVariable<Set>("Set/Group");
+//  auto &set_mixelem = data_store.getVariable<Set>("Set/MixElem");
+//
+//  auto &field_phi_out = data_store.getVariable<Kripke::Field_Moments>("phi_out");
+//
+//  auto &field_mixed_to_zone     = data_store.getVariable<Field_MixElem2Zone>("mixelem_to_zone");
+//  auto &field_mixed_to_material = data_store.getVariable<Field_MixElem2Material>("mixelem_to_material");
+//  auto &field_mixed_to_fraction = data_store.getVariable<Field_MixElem2Double>("mixelem_to_fraction");
+//
+//  double source_strength = 1.0;
+//
+//
+//  // Loop over zoneset subdomains
+//  for(auto sdom_id : field_phi_out.getWorkList()){
+//
+//    Kripke::dispatch(al_v, SourceSdom{}, sdom_id,
+//                     set_group, set_mixelem,
+//                     field_phi_out,
+//                     field_mixed_to_zone,
+//                     field_mixed_to_material,
+//                     field_mixed_to_fraction,
+//                     source_strength);
+//
+//  }
+//
+//
+//}

--- a/src/Kripke/SteadyStateSolver.cpp
+++ b/src/Kripke/SteadyStateSolver.cpp
@@ -78,7 +78,7 @@ int Kripke::SteadyStateSolver (Kripke::Core::DataStore &data_store, size_t max_i
     Kripke::Kernel::kConst(data_store.getVariable<Field_Moments>("phi"), 0.0);
     
     //Kripke::Kernel::LTimes(data_store);
-    Kripke::Kernel::LTimesJit<std::string("Kripke::ArchLayout")>(data_store);
+    Kripke::Kernel::template LTimesJit<std::string("Kripke::ArchLayout")>(data_store);
 
 
 

--- a/src/Kripke/SteadyStateSolver.cpp
+++ b/src/Kripke/SteadyStateSolver.cpp
@@ -78,7 +78,7 @@ int Kripke::SteadyStateSolver (Kripke::Core::DataStore &data_store, size_t max_i
     Kripke::Kernel::kConst(data_store.getVariable<Field_Moments>("phi"), 0.0);
     
     //Kripke::Kernel::LTimes(data_store);
-    Kripke::Kernel::template LTimesJit<std::string("Kripke::ArchLayout")>(data_store);
+    Kripke::Kernel::template LTimesJit<std::string("Kripke::ArchLayoutT<Kripke::ArchT_Sequential,Kripke::LayoutT_DGZ>")>(data_store);
 
 
 

--- a/src/Kripke/SteadyStateSolver.cpp
+++ b/src/Kripke/SteadyStateSolver.cpp
@@ -76,7 +76,9 @@ int Kripke::SteadyStateSolver (Kripke::Core::DataStore &data_store, size_t max_i
 
     // Discrete to Moments transformation (phi = L*psi)
     Kripke::Kernel::kConst(data_store.getVariable<Field_Moments>("phi"), 0.0);
-    Kripke::Kernel::LTimes(data_store);
+    
+    //Kripke::Kernel::LTimes(data_store);
+    Kripke::Kernel::LTimesJit<std::string("Kripke::ArchLayout")>(data_store);
 
 
 


### PR DESCRIPTION
This isn't intended as a thing which gets merged into Kripke, more of a discussion space, probably to be closed after the Supercomputing submission.

This demonstrates the use of @hfinkel's [JIT Compiler](https://github.com/hfinkel/llvm-project-cxxjit/wiki) prototype in Clang. Notably, it allows template parameters to be runtime values. In the case of "typename" parameters, you pass said type as a string (or thing which can be converted to a string). I've gone ahead and done a lot of Kripke in this style. Notably, compile times of individual files drop precipitously, Scattering.cpp takes about 30% as long to compile (more details in first comment) as compared to a non-JIT version.

Link time spikes, you're linking in all of Clang statically (you _can_ link it dynamically, I just know LLNL codes tend not to link libraries dynamicallly), I don't know good answers for that other than to link dynamically.

Runtime is comparable, we're not doing anything to speed up the code, so it looks like the overhead is a constant extra two seconds per run spent in Solve. If your run takes 15 seconds, this is a disaster. If it takes an hour, you don't care.

Anyway, I'll be trying out different patterns here, questions are welcome.