### PR TITLE
work around lack of sched_getcpu on MacOS

### DIFF
--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -267,6 +267,8 @@ int main(int argc, char **argv) {
       int tid = omp_get_thread_num();
 #ifdef __bgq__
       int core = Kernel_ProcessorCoreID();
+#elif __APPLE__
+      int core = -1;
 #else
       int core = sched_getcpu();
 #endif


### PR DESCRIPTION
Fixes this error:
```
Scanning dependencies of target kripke.exe
[ 98%] Building CXX object CMakeFiles/kripke.exe.dir/src/kripke.cpp.o
Kripke/source/src/kripke.cpp(271): error: identifier "sched_getcpu" is undefined
        int core = sched_getcpu();
                   ^

compilation aborted for 
Kripke/source/src/kripke.cpp (code 2)
make[2]: *** [CMakeFiles/kripke.exe.dir/src/kripke.cpp.o] Error 2
make[1]: *** [CMakeFiles/kripke.exe.dir/all] Error 2
make: *** [all] Error 2
```