### PR TITLE
WIP: Fix for device transfer bug.

### DIFF
--- a/src/Kripke/Kernel/LPlusTimes.cpp
+++ b/src/Kripke/Kernel/LPlusTimes.cpp
@@ -40,10 +40,23 @@ struct LPlusTimesSdom {
     int num_moments =    set_moment.size(sdom_id);
     int num_zones =      set_zone.size(sdom_id);
 
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveHtoD(field_phi_out);
+    sdom_al.moveHtoD(field_rhs);
+    sdom_al.moveHtoD(field_ell_plus);
+    // Get views
+    auto phi_out  = sdom_al.getDeviceView(field_phi_out);
+    auto rhs      = sdom_al.getDeviceView(field_rhs);
+    auto ell_plus = sdom_al.getDeviceView(field_ell_plus); 
+#endif
+#else
     // Get views
     auto phi_out  = sdom_al.getView(field_phi_out);
     auto rhs      = sdom_al.getView(field_rhs);
     auto ell_plus = sdom_al.getView(field_ell_plus); 
+#endif
 
     // Compute:  rhs =  ell_plus * phi_out
     RAJA::kernel<ExecPolicy>(
@@ -58,6 +71,15 @@ struct LPlusTimesSdom {
 
         }
     );
+
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveDtoH(field_phi_out);
+    sdom_al.moveDtoH(field_rhs);
+    sdom_al.moveDtoH(field_ell_plus);
+#endif
+#endif
   }
 
 };

--- a/src/Kripke/Kernel/Population.cpp
+++ b/src/Kripke/Kernel/Population.cpp
@@ -42,9 +42,21 @@ struct PopulationSdom {
     int num_groups =     set_group.size(sdom_id);
     int num_zones =      set_zone.size(sdom_id);
 
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveHtoD(field_psi);
+    sdom_al.moveHtoD(field_w);
+    sdom_al.moveHtoD(field_volume);
+    auto psi    = sdom_al.getDeviceView(field_psi);
+    auto w      = sdom_al.getDeviceView(field_w);
+    auto volume = sdom_al.getDeviceView(field_volume);
+#endif
+#else
     auto psi    = sdom_al.getView(field_psi);
     auto w      = sdom_al.getView(field_w);
     auto volume = sdom_al.getView(field_volume);
+#endif
     
     RAJA::ReduceSum<ReducePolicy, double> part_red(0.0);
 
@@ -59,6 +71,15 @@ struct PopulationSdom {
 
         }
     );
+
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveDtoH(field_psi);
+    sdom_al.moveDtoH(field_w);
+    sdom_al.moveDtoH(field_volume);
+#endif
+#endif
 
     *part_ptr += (double)part_red;
   }

--- a/src/Kripke/Kernel/Scattering.cpp
+++ b/src/Kripke/Kernel/Scattering.cpp
@@ -52,6 +52,33 @@ struct ScatteringSdom {
     int glower_dst = set_group.lower(sdom_dst);
 
 
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveHtoD(field_moment_to_legendre);
+    sdom_al.moveHtoD(field_phi);
+    sdom_al.moveHtoD(field_phi_out);
+    sdom_al.moveHtoD(field_sigs);
+
+    sdom_al.moveHtoD(field_zone_to_mixelem);
+    sdom_al.moveHtoD(field_zone_to_num_mixelem);
+    sdom_al.moveHtoD(field_mixelem_to_material);
+    sdom_al.moveHtoD(field_mixelem_to_fraction);
+
+    // get material mix information
+    auto moment_to_legendre = sdom_al.getDeviceView(field_moment_to_legendre);
+
+    auto phi     = sdom_al.getDeviceView(field_phi);
+    auto phi_out = sdom_al.getDeviceView(field_phi_out, sdom_dst);
+    auto sigs    = sdom_al.getDeviceView(field_sigs);
+    
+    auto zone_to_mixelem     = sdom_al.getDeviceView(field_zone_to_mixelem);
+    auto zone_to_num_mixelem = sdom_al.getDeviceView(field_zone_to_num_mixelem);
+    auto mixelem_to_material = sdom_al.getDeviceView(field_mixelem_to_material);
+    auto mixelem_to_fraction = sdom_al.getDeviceView(field_mixelem_to_fraction);
+#endif
+
+#else
     // get material mix information
     auto moment_to_legendre = sdom_al.getView(field_moment_to_legendre);
 
@@ -63,6 +90,7 @@ struct ScatteringSdom {
     auto zone_to_num_mixelem = sdom_al.getView(field_zone_to_num_mixelem);
     auto mixelem_to_material = sdom_al.getView(field_mixelem_to_material);
     auto mixelem_to_fraction = sdom_al.getView(field_mixelem_to_fraction);
+#endif
     
     // grab dimensions
     int num_zones =      set_zone.size(sdom_src);
@@ -97,6 +125,21 @@ struct ScatteringSdom {
             phi_out(nm, g, z) += sigs_z * phi(nm, gp, z);
         }
     );
+
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to CPU
+    sdom_al.moveDtoH(field_moment_to_legendre);
+    sdom_al.moveDtoH(field_phi);
+    sdom_al.moveDtoH(field_phi_out);
+    sdom_al.moveDtoH(field_sigs);
+
+    sdom_al.moveDtoH(field_zone_to_mixelem);
+    sdom_al.moveDtoH(field_zone_to_num_mixelem);
+    sdom_al.moveDtoH(field_mixelem_to_material);
+    sdom_al.moveDtoH(field_mixelem_to_fraction);
+#endif
+#endif
   }
 
 };

--- a/src/Kripke/Kernel/Source.cpp
+++ b/src/Kripke/Kernel/Source.cpp
@@ -45,11 +45,27 @@ struct SourceSdom {
     // Source term is isotropic
     Moment nm{0};
 
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveHtoD(field_phi_out);
+    sdom_al.moveHtoD(field_mixed_to_zone);
+    sdom_al.moveHtoD(field_mixed_to_material);
+    sdom_al.moveHtoD(field_mixed_to_fraction);
+
+    auto phi_out = sdom_al.getDeviceView(field_phi_out);
+
+    auto mixelem_to_zone     = sdom_al.getDeviceView(field_mixed_to_zone);
+    auto mixelem_to_material = sdom_al.getDeviceView(field_mixed_to_material);
+    auto mixelem_to_fraction = sdom_al.getDeviceView(field_mixed_to_fraction);
+#endif
+#else
     auto phi_out = sdom_al.getView(field_phi_out);
 
     auto mixelem_to_zone     = sdom_al.getView(field_mixed_to_zone);
     auto mixelem_to_material = sdom_al.getView(field_mixed_to_material);
     auto mixelem_to_fraction = sdom_al.getView(field_mixed_to_fraction);
+#endif
 
     int num_mixed  = set_mixelem.size(sdom_id);
     int num_groups = set_group.size(sdom_id);
@@ -74,6 +90,15 @@ struct SourceSdom {
         }
     );
 
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    // Move data to GPU
+    sdom_al.moveDtoH(field_phi_out);
+    sdom_al.moveDtoH(field_mixed_to_zone);
+    sdom_al.moveDtoH(field_mixed_to_material);
+    sdom_al.moveDtoH(field_mixed_to_fraction);
+#endif
+#endif
   }
 };
 

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -128,6 +128,39 @@ namespace Kripke {
     {
       return field.template getViewOrder<order_t>(sdom);
     }
+
+#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_CUDA
+    template<typename FieldType>
+    auto getDeviceView(FieldType &field) const ->
+      decltype(field.template getDeviceViewOrder<order_t>(sdom_id))
+    {
+      return field.template getDeviceViewOrder<order_t>(sdom_id);
+    }
+    
+    template<typename FieldType>
+    auto getDeviceView(FieldType &field, Kripke::SdomId sdom) const ->
+      decltype(field.template getDeviceViewOrder<order_t>(sdom))
+    {
+      return field.template getDeviceViewOrder<order_t>(sdom);
+    }
+
+    template<typename FieldType>
+    void moveHtoD(FieldType &field) const //->
+      //decltype(field.template moveHtoD(sdom_id))
+    {
+      printf( "RCC INSIDE move H to D\n" );
+      field.template moveHtoD(sdom_id);
+    }
+    
+    template<typename FieldType>
+    void moveDtoH(FieldType &field) const //->
+      //decltype(field.template moveDtoH(sdom_id))
+    {
+      field.template moveDtoH(sdom_id);
+    }
+#endif
+#endif
   };
 
   template<typename AL>


### PR DESCRIPTION
When using CUDA with ATS disabled, memory is not being transferred to the device in kernels, causing illegal warp addresses and seg faults on the GPU. This PR manually transfers memory to and from the GPU, and obtains the correct GPU pointers from CHAI.

Try this out with the following steps:

1. lalloc 1 --atsdisable
2. cd kripke
3. mkdir build ; cd build
4. cmake -C ../host-configs/llnl-blueos-P100-nvcc-clang.cmake -DBLT_CXX_STD=c++14 -DCMAKE_BUILD_TYPE=Debug -DENABLE_CUDA=On -DCHAI_DEBUG=On -DCUDA_ARCH=sm_70 -DCHAI_ENABLE_UM=1 -DENABLE_UM=1 ..
5. make -j 40
6. ./bin/kripke.exe

- [ ] @vsrana01 should test this with HIP.
- [ ] After HIP testing, clean up the design of this fix.