### PR TITLE
Revert TOSS3 cmake to clang 8.

### DIFF
--- a/host-configs/llnl-toss3-clang8.cmake
+++ b/host-configs/llnl-toss3-clang8.cmake
@@ -9,9 +9,9 @@
 
 set(RAJA_COMPILER "RAJA_COMPILER_CLANG" CACHE STRING "")
 
-set(CMAKE_C_COMPILER   "/usr/tce/bin/clang-13.0.0" CACHE PATH "")
-set(CMAKE_CXX_COMPILER "/usr/tce/bin/clang++-13.0.0" CACHE PATH "")
-set(CMAKE_LINKER       "/usr/tce/bin/clang++-13.0.0" CACHE PATH "")
+set(CMAKE_C_COMPILER   "/usr/tce/bin/clang-8.0.0" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/bin/clang++-8.0.0" CACHE PATH "")
+set(CMAKE_LINKER       "/usr/tce/bin/clang++-8.0.0" CACHE PATH "")
 
 set(CMAKE_CXX_FLAGS "" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math" CACHE STRING "")


### PR DESCRIPTION
Clang 13 is still giving us compilation errors on TOSS3. Reverting back to clang/8.0.0 for now, while this gets sorted out (https://github.com/LLNL/Kripke/issues/37).