### PR TITLE
Fix Caliper annotation scope

### DIFF
--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -460,6 +460,8 @@ int main(int argc, char **argv) {
    */
 
 #ifdef KRIPKE_USE_CALIPER
+  cali_config_set("CALI_CALIPER_ATTRIBUTE_DEFAULT_SCOPE", "process");
+
   void* adiak_mpi_comm_ptr = nullptr;
 #ifdef KRIPKE_USE_MPI
   MPI_Comm adiak_mpi_comm = MPI_COMM_WORLD;


### PR DESCRIPTION
We ran into an issue with the Caliper annotation for the solver loop not appearing in the correct (process) scope. Here's the fix.