### PR TITLE
Fix policy ordering for CUDA and HIP policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ if (ENABLE_CHAI)
   set(CHAI_ENABLE_RAJA_PLUGIN On CACHE BOOL "")
 endif ()
 
-# Use C++14 standard
-set(BLT_CXX_STD "c++14" CACHE STRING "")
+# Use C++17 standard
+set(BLT_CXX_STD "c++17" CACHE STRING "")
 
 if (NOT BLT_LOADED)
   if (DEFINED BLT_SOURCE_DIR)
@@ -50,7 +50,7 @@ if (NOT BLT_LOADED)
     endif ()
  endif ()
 
-  set(BLT_CXX_STD "c++14" CACHE STRING "BLT requires C++14")
+  set(BLT_CXX_STD "c++17" CACHE STRING "BLT requires C++17")
   set(ENABLE_ALL_WARNINGS OFF CACHE BOOL "")
   set(ENABLE_ASTYLE OFF CACHE BOOL "")
   set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -244,8 +244,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<256,
-          For<2, RAJA::cuda_global_size_z_direct<8>, // group
-            For<0, RAJA::cuda_global_size_y_direct<8>, // moment
+          For<2, RAJA::cuda_global_size_z_direct<2>, // group
+            For<0, RAJA::cuda_global_size_y_direct<4>, // moment
               For<1, RAJA::cuda_global_size_x_direct<32>, // direction
                 For<3, seq_exec, // zone
                   Lambda<0>

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -350,22 +350,41 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
       >;
 };
 
+// template<>
+// struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
+//     using ExecPolicy =
+//       KernelPolicy<
+//         HipKernel<
+//           For<2, hip_block_x_loop, // group
+//             For<0, hip_block_y_loop, // moment
+//               For<1, hip_thread_x_loop, // direction
+//                 For<3, seq_exec, // zone
+//                   Lambda<0>
+//                 >
+//               >
+//             >
+//           >
+//         >
+//       >;
+// };
+
+
 template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
     using ExecPolicy =
-      KernelPolicy<
-        HipKernel<
-          For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
-              For<1, hip_thread_x_loop, // direction
-                For<3, seq_exec, // zone
-                  Lambda<0>
+        RAJA::KernelPolicy<
+          RAJA::statement::HipKernelFixedAsync<256,
+            RAJA::statement::For<2, RAJA::hip_global_size_z_direct<2>,     //g
+              RAJA::statement::For<0, RAJA::hip_global_size_y_direct<4>,   //m
+                RAJA::statement::For<1, RAJA::hip_global_size_x_direct<32>, //d
+                  RAJA::statement::For<3, RAJA::seq_exec,          //z
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 };
 
 template<>

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -243,10 +243,10 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernel<
-          For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
-              For<1, cuda_thread_x_loop, // direction
+        CudaKernelFixedAsync<256,
+          For<2, RAJA::cuda_global_size_z_direct<8>, // group
+            For<0, RAJA::cuda_global_size_y_direct<8>, // moment
+              For<1, RAJA::cuda_global_size_x_direct<32>, // direction
                 For<3, seq_exec, // zone
                   Lambda<0>
                 >

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -293,14 +293,32 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
       >;
 };
 
+// template<>
+// struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
+//     using ExecPolicy =
+//       KernelPolicy<
+//         CudaKernel<
+//           For<3, cuda_block_x_loop, // zone
+//             For<2, cuda_block_y_loop, // group
+//               For<0, cuda_thread_x_loop, // moment
+//                 For<1, seq_exec, // direction
+//                   Lambda<0>
+//                 >
+//               >
+//             >
+//           >
+//         >
+//       >;
+// };
+
 template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernel<
-          For<3, cuda_block_x_loop, // zone
-            For<2, cuda_block_y_loop, // group
-              For<0, cuda_thread_x_loop, // moment
+        RAJA::statement::CudaKernelFixedAsync<256,
+          For<3, RAJA::cuda_global_size_z_direct<2>, // zone
+            For<2, RAJA::cuda_global_size_y_direct<4>, // group
+              For<0, RAJA::cuda_global_size_x_direct<32>, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -310,6 +328,7 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
         >
       >;
 };
+
 #endif // KRIPKE_USE_CUDA
 
 
@@ -423,14 +442,33 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
       >;
 };
 
+// template<>
+// struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
+//     using ExecPolicy =
+//       KernelPolicy<
+//         HipKernel<
+//           For<3, hip_block_x_loop, // zone
+//             For<2, hip_block_y_loop, // group
+//               For<0, hip_thread_x_loop, // moment
+//                 For<1, seq_exec, // direction
+//                   Lambda<0>
+//                 >
+//               >
+//             >
+//           >
+//         >
+//       >;
+// };
+
+
 template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernel<
-          For<3, hip_block_x_loop, // zone
-            For<2, hip_block_y_loop, // group
-              For<0, hip_thread_x_loop, // moment
+        RAJA::statement::HipKernelFixedAsync<256,
+          For<3, RAJA::hip_global_size_z_direct<2>, // zone
+            For<2, RAJA::hip_global_size_y_direct<4>, // group
+              For<0, RAJA::hip_global_size_x_direct<32>, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -440,6 +478,7 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
         >
       >;
 };
+
 #endif // KRIPKE_USE_HIP
 }
 }

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -208,10 +208,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
       CudaKernel<
-        For<2, cuda_block_x_loop, // group
-          For<0, cuda_block_y_loop, // moment
-            For<3, cuda_thread_x_loop, // zone
-              For<1, seq_exec, // direction
+        For<0, cuda_block_x_loop, // moment
+          For<1, cuda_block_y_loop, // direction
+            For<2, cuda_thread_x_loop, // group
+              For<3, seq_exec, // zone
                 Lambda<0>
               >
             >
@@ -226,10 +226,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernel<
-          For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
+          For<0, cuda_block_x_loop, // moment
+            For<1, cuda_block_y_loop, // direction
               For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -246,8 +246,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
         CudaKernel<
           For<2, cuda_block_x_loop, // group
             For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, cuda_thread_x_loop, // direction
+                For<3, seq_exec, // zone
                   Lambda<0>
                 >
               >
@@ -263,8 +263,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
       KernelPolicy<
         CudaKernel<
           For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
+            For<3, cuda_block_y_loop, // zone
+              For<0, cuda_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -280,10 +280,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernel<
-          For<2, cuda_block_x_loop, // group
+          For<3, cuda_block_x_loop, // zone
             For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, cuda_thread_x_loop, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -298,9 +298,9 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernel<
-          For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
+          For<3, cuda_block_x_loop, // zone
+            For<2, cuda_block_y_loop, // group
+              For<0, cuda_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -319,10 +319,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
       HipKernel<
-        For<2, hip_block_x_loop, // group
-          For<0, hip_block_y_loop, // moment
-            For<3, hip_thread_x_loop, // zone
-              For<1, seq_exec, // direction
+        For<0, hip_block_x_loop, // moment
+          For<1, hip_block_y_loop, // direction
+            For<2, hip_thread_x_loop, // group
+              For<3, seq_exec, // zone
                 Lambda<0>
               >
             >
@@ -337,10 +337,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernel<
-          For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
+          For<0, hip_block_x_loop, // moment
+            For<1, hip_block_y_loop, // direction
               For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -357,8 +357,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
         HipKernel<
           For<2, hip_block_x_loop, // group
             For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, hip_thread_x_loop, // direction
+                For<3, seq_exec, // zone
                   Lambda<0>
                 >
               >
@@ -374,8 +374,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
       KernelPolicy<
         HipKernel<
           For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
+            For<3, hip_block_y_loop, // zone
+              For<0, hip_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -391,10 +391,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernel<
-          For<2, hip_block_x_loop, // group
+          For<3, hip_block_x_loop, // zone
             For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, hip_thread_x_loop, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -409,9 +409,9 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernel<
-          For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
+          For<3, hip_block_x_loop, // zone
+            For<2, hip_block_y_loop, // group
+              For<0, hip_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -243,7 +243,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelFixedAsync<256,
+        RAJA::statement::CudaKernelFixedAsync<256,
           For<2, RAJA::cuda_global_size_z_direct<8>, // group
             For<0, RAJA::cuda_global_size_y_direct<8>, // moment
               For<1, RAJA::cuda_global_size_x_direct<32>, // direction

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -243,7 +243,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        RAJA::statement::CudaKernelFixedAsync<256,
+        RAJA::statement::udaKernelFixedAsync<256,
           For<2, RAJA::cuda_global_size_z_direct<8>, // group
             For<0, RAJA::cuda_global_size_y_direct<8>, // moment
               For<1, RAJA::cuda_global_size_x_direct<32>, // direction

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -243,7 +243,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        RAJA::statement::udaKernelFixedAsync<256,
+        RAJA::statement::CudaKernelFixedAsync<256,
           For<2, RAJA::cuda_global_size_z_direct<8>, // group
             For<0, RAJA::cuda_global_size_y_direct<8>, // moment
               For<1, RAJA::cuda_global_size_x_direct<32>, // direction

--- a/src/Kripke/Generate/Data.cpp
+++ b/src/Kripke/Generate/Data.cpp
@@ -63,9 +63,12 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
   Set const &zonei_set = data_store.getVariable<Set>("Set/ZoneI");
   Set const &zonej_set = data_store.getVariable<Set>("Set/ZoneJ");
   Set const &zonek_set = data_store.getVariable<Set>("Set/ZoneK");
-  Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, dir_set, group_set, zonej_set, zonek_set);
-  Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonek_set);
-  Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonej_set);
+  // Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, dir_set, group_set, zonej_set, zonek_set);
+  // Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonek_set);
+  // Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonej_set);
+  Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, zonej_set, zonek_set, group_set, dir_set);
+  Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR,  zonei_set, zonek_set, group_set, dir_set);
+  Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, zonei_set, zonej_set, group_set, dir_set);
   createField<Field_IPlane>(data_store, "i_plane", al_v, iplane_set);
   createField<Field_JPlane>(data_store, "j_plane", al_v, jplane_set);
   createField<Field_KPlane>(data_store, "k_plane", al_v, kplane_set);

--- a/src/Kripke/Generate/Data.cpp
+++ b/src/Kripke/Generate/Data.cpp
@@ -30,10 +30,8 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
   Set const &dir_set   = data_store.getVariable<Set>("Set/Direction");
   Set const &group_set = data_store.getVariable<Set>("Set/Group");
   Set const &zone_set  = data_store.getVariable<Set>("Set/Zone");
-  // ProductSet<3> *flux_set = new ProductSet<3>(pspace, SPACE_PQR,
-  //     dir_set, group_set, zone_set);
   ProductSet<3> *flux_set = new ProductSet<3>(pspace, SPACE_PQR,
-    zone_set, group_set, dir_set);
+      dir_set, group_set, zone_set);
 
   data_store.addVariable("Set/Flux", flux_set);
 
@@ -46,10 +44,8 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
 
   // Create a set to span moments of the angular flux
   Set const &moment_set   = data_store.getVariable<Set>("Set/Moment");
-  // ProductSet<3> *fluxmoment_set = new ProductSet<3>(pspace, SPACE_PR,
-  //       moment_set, group_set, zone_set);
   ProductSet<3> *fluxmoment_set = new ProductSet<3>(pspace, SPACE_PR,
-      zone_set, group_set, moment_set);
+        moment_set, group_set, zone_set);
 
   data_store.addVariable("Set/FluxMoment", fluxmoment_set);
 
@@ -63,12 +59,9 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
   Set const &zonei_set = data_store.getVariable<Set>("Set/ZoneI");
   Set const &zonej_set = data_store.getVariable<Set>("Set/ZoneJ");
   Set const &zonek_set = data_store.getVariable<Set>("Set/ZoneK");
-  // Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, dir_set, group_set, zonej_set, zonek_set);
-  // Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonek_set);
-  // Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonej_set);
-  Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, zonej_set, zonek_set, group_set, dir_set);
-  Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR,  zonei_set, zonek_set, group_set, dir_set);
-  Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, zonei_set, zonej_set, group_set, dir_set);
+  Set const &iplane_set = data_store.newVariable<ProductSet<4>>("Set/IPlane", pspace, SPACE_PQR, dir_set, group_set, zonej_set, zonek_set);
+  Set const &jplane_set = data_store.newVariable<ProductSet<4>>("Set/JPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonek_set);
+  Set const &kplane_set = data_store.newVariable<ProductSet<4>>("Set/KPlane", pspace, SPACE_PQR, dir_set, group_set, zonei_set, zonej_set);
   createField<Field_IPlane>(data_store, "i_plane", al_v, iplane_set);
   createField<Field_JPlane>(data_store, "j_plane", al_v, jplane_set);
   createField<Field_KPlane>(data_store, "k_plane", al_v, kplane_set);
@@ -110,7 +103,3 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
 
 
 }
-
-
-
-

--- a/src/Kripke/Generate/Data.cpp
+++ b/src/Kripke/Generate/Data.cpp
@@ -30,8 +30,10 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
   Set const &dir_set   = data_store.getVariable<Set>("Set/Direction");
   Set const &group_set = data_store.getVariable<Set>("Set/Group");
   Set const &zone_set  = data_store.getVariable<Set>("Set/Zone");
+  // ProductSet<3> *flux_set = new ProductSet<3>(pspace, SPACE_PQR,
+  //     dir_set, group_set, zone_set);
   ProductSet<3> *flux_set = new ProductSet<3>(pspace, SPACE_PQR,
-      dir_set, group_set, zone_set);
+    zone_set, group_set, dir_set);
 
   data_store.addVariable("Set/Flux", flux_set);
 
@@ -44,8 +46,10 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
 
   // Create a set to span moments of the angular flux
   Set const &moment_set   = data_store.getVariable<Set>("Set/Moment");
+  // ProductSet<3> *fluxmoment_set = new ProductSet<3>(pspace, SPACE_PR,
+  //       moment_set, group_set, zone_set);
   ProductSet<3> *fluxmoment_set = new ProductSet<3>(pspace, SPACE_PR,
-        moment_set, group_set, zone_set);
+      zone_set, group_set, moment_set);
 
   data_store.addVariable("Set/FluxMoment", fluxmoment_set);
 

--- a/src/Kripke/Generate/Space.cpp
+++ b/src/Kripke/Generate/Space.cpp
@@ -187,7 +187,7 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
 
   // number of subsamples per spatial dimension
   int num_subsamples = input_vars.num_material_subsamples;
-  std::cout << "test121212 " << num_subsamples << std::endl;
+  //std::cout << "test121212 " << num_subsamples << std::endl;
   double sample_vol_frac = 1.0 / (double)(num_subsamples*num_subsamples*num_subsamples);
 
   auto sdom_list = set_zone.getWorkList();

--- a/src/Kripke/Generate/Space.cpp
+++ b/src/Kripke/Generate/Space.cpp
@@ -187,6 +187,7 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
 
   // number of subsamples per spatial dimension
   int num_subsamples = input_vars.num_material_subsamples;
+  std::cout << "test121212 " << num_subsamples << std::endl;
   double sample_vol_frac = 1.0 / (double)(num_subsamples*num_subsamples*num_subsamples);
 
   auto sdom_list = set_zone.getWorkList();

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -51,7 +51,6 @@ struct LTimesSdom {
     auto ell = sdom_al.getView(field_ell);
 
     // Compute:  phi =  ell * psi
-    cali_begin_region("ltimes_kernel");
     RAJA::kernel<ExecPolicy>(
         camp::make_tuple(
             RAJA::TypedRangeSegment<Moment>(0, num_moments),
@@ -64,13 +63,7 @@ struct LTimesSdom {
 
         }
     );
-    #ifdef KRIPKE_USE_HIP
-      hipDeviceSynchronize();
-    #elif defined(KRIPKE_USE_CUDA)
-      cudaDeviceSynchronize();
-    #endif
-    MPI_Barrier(MPI_COMM_WORLD);
-    cali_end_region("ltimes_kernel");
+
   }
 
 };
@@ -98,15 +91,25 @@ void Kripke::Kernel::LTimes(Kripke::Core::DataStore &data_store)
   auto &field_ell =       data_store.getVariable<Field_Ell>("ell");
 
   // Loop over Subdomains
+  int i = 0;
   for (Kripke::SdomId sdom_id : field_psi.getWorkList()){
-
+    std::string region_name = "ltimes_kernel_" + std::to_string(i);
+    cali_begin_region(region_name.c_str());
 
     Kripke::dispatch(al_v, LTimesSdom{}, sdom_id,
                      set_dir, set_group, set_zone, set_moment,
                      field_psi, field_phi, field_ell);
 
-
+    #ifdef KRIPKE_USE_HIP
+      hipDeviceSynchronize();
+    #elif defined(KRIPKE_USE_CUDA)
+      cudaDeviceSynchronize();
+    #endif
+    MPI_Barrier(MPI_COMM_WORLD);
+    cali_end_region(region_name.c_str());
+    i = i + 1;
   }
+
 
 }
 

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -64,11 +64,12 @@ struct LTimesSdom {
 
         }
     );
-    //cudaDeviceSynchronize();
-    hipDeviceSynchronize();
+    #ifdef KRIPKE_USE_HIP
+      hipDeviceSynchronize();
+    #elif defined(KRIPKE_USE_CUDA)
+      cudaDeviceSynchronize();
+    #endif
     cali_end_region("ltimes_kernel");
-
-
   }
 
 };

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -51,6 +51,7 @@ struct LTimesSdom {
     auto ell = sdom_al.getView(field_ell);
 
     // Compute:  phi =  ell * psi
+    CALI_MARK_BEGIN("ltimes_kernel");
     RAJA::kernel<ExecPolicy>(
         camp::make_tuple(
             RAJA::TypedRangeSegment<Moment>(0, num_moments),
@@ -63,6 +64,7 @@ struct LTimesSdom {
 
         }
     );
+    CALI_MARK_END("ltimes_kernel");
 
 
   }

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -64,7 +64,8 @@ struct LTimesSdom {
 
         }
     );
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
+    hipDeviceSynchronize();
     cali_end_region("ltimes_kernel");
 
 

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -69,6 +69,7 @@ struct LTimesSdom {
     #elif defined(KRIPKE_USE_CUDA)
       cudaDeviceSynchronize();
     #endif
+    MPI_Barrier(MPI_COMM_WORLD);
     cali_end_region("ltimes_kernel");
   }
 

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -45,11 +45,16 @@ struct LTimesSdom {
     int num_moments =    set_moment.size(sdom_id);
     int num_zones =      set_zone.size(sdom_id);
 
+    std::cout << "d=" << num_directions << " g=" << num_groups << " m=" << num_moments << " z=" << num_zones << std::endl;
+
     // Get pointers
     auto psi = sdom_al.getView(field_psi);
     auto phi = sdom_al.getView(field_phi);
     auto ell = sdom_al.getView(field_ell);
 
+    std::cout << "psi=" << psi.size() << " phi=" << phi.size() << " ell=" << ell.size() << std::endl;
+
+    cali_begin_region("ltimessdom_kernel");
     // Compute:  phi =  ell * psi
     RAJA::kernel<ExecPolicy>(
         camp::make_tuple(
@@ -63,6 +68,13 @@ struct LTimesSdom {
 
         }
     );
+    #ifdef KRIPKE_USE_HIP
+      hipDeviceSynchronize();
+    #elif defined(KRIPKE_USE_CUDA)
+      cudaDeviceSynchronize();
+    #endif
+    MPI_Barrier(MPI_COMM_WORLD);
+    cali_end_region("ltimessdom_kernel");
 
   }
 

--- a/src/Kripke/Kernel/LTimes.cpp
+++ b/src/Kripke/Kernel/LTimes.cpp
@@ -51,7 +51,7 @@ struct LTimesSdom {
     auto ell = sdom_al.getView(field_ell);
 
     // Compute:  phi =  ell * psi
-    CALI_MARK_BEGIN("ltimes_kernel");
+    cali_begin_region("ltimes_kernel");
     RAJA::kernel<ExecPolicy>(
         camp::make_tuple(
             RAJA::TypedRangeSegment<Moment>(0, num_moments),
@@ -64,7 +64,8 @@ struct LTimesSdom {
 
         }
     );
-    CALI_MARK_END("ltimes_kernel");
+    cudaDeviceSynchronize();
+    cali_end_region("ltimes_kernel");
 
 
   }


### PR DESCRIPTION
note: This is for studying 1 subdomain at a time (not for merging)

We noticed some of the `CUDA` and `HIP` policies appear to be identical, despite attempting to define different layouts. It would appear that all of these layouts currently execute the `GZD` policy.

- [ ] Should only the `ArgumentId` nesting match the ordering of the sequential policy or does the `ExecPolicy` nesting also need to change?
- [ ] I noticed a similar looking issue for `LPlusTimes.h`, which I have not corrected here, and I have not checked the policies in other files.
