### PR TITLE
Fix Loop Orderings

### DIFF
--- a/src/Kripke/Arch/LPlusTimes.h
+++ b/src/Kripke/Arch/LPlusTimes.h
@@ -233,8 +233,8 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
       KernelPolicy<
         CudaKernelAsync<
           For<0, cuda_block_x_loop, // Direction
-            For<2, cuda_block_y_loop, // group
-              For<3, cuda_thread_x_loop, // zone
+            For<3, cuda_block_y_loop, // zone
+              For<2, cuda_thread_x_loop, // group
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -250,8 +250,8 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<0, cuda_block_x_loop, // Direction
-            For<2, cuda_block_y_loop, // group
+          For<2, cuda_block_x_loop, // group
+            For<0, cuda_block_y_loop, // direction
               For<3, cuda_thread_x_loop, // zone
                 For<1, seq_exec, // Moment
                   Lambda<0>
@@ -269,9 +269,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<0, cuda_block_x_loop, // Direction
-            For<2, cuda_block_y_loop, // group
-              For<3, cuda_thread_x_loop, // zone
+          For<2, cuda_block_x_loop, // group
+            For<3, cuda_block_y_loop, // zone
+              For<0, cuda_thread_x_loop, // direction
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -287,9 +287,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<0, cuda_block_x_loop, // Direction
-            For<2, cuda_block_y_loop, // group
-              For<3, cuda_thread_x_loop, // zone
+          For<3, cuda_block_x_loop, // zone
+            For<0, cuda_block_y_loop, // direction
+              For<2, cuda_thread_x_loop, // group
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -307,9 +307,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<0, cuda_block_x_loop, // Direction
+          For<3, cuda_block_x_loop, // zone
             For<2, cuda_block_y_loop, // group
-              For<3, cuda_thread_x_loop, // zone
+              For<0, cuda_thread_x_loop, // direction
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -349,8 +349,8 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
       KernelPolicy<
         HipKernelAsync<
           For<0, hip_block_x_loop, // Direction
-            For<2, hip_block_y_loop, // group
-              For<3, hip_thread_x_loop, // zone
+            For<3, hip_block_y_loop, // zone
+              For<2, hip_thread_x_loop, // group
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -366,8 +366,8 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<0, hip_block_x_loop, // Direction
-            For<2, hip_block_y_loop, // group
+          For<2, hip_block_x_loop, // group
+            For<0, hip_block_y_loop, // direction
               For<3, hip_thread_x_loop, // zone
                 For<1, seq_exec, // Moment
                   Lambda<0>
@@ -385,9 +385,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<0, hip_block_x_loop, // Direction
-            For<2, hip_block_y_loop, // group
-              For<3, hip_thread_x_loop, // zone
+          For<2, hip_block_x_loop, // group
+            For<3, hip_block_y_loop, // zone
+              For<0, hip_thread_x_loop, // direction
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -403,9 +403,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<0, hip_block_x_loop, // Direction
-            For<2, hip_block_y_loop, // group
-              For<3, hip_thread_x_loop, // zone
+          For<3, hip_block_x_loop, // zone
+            For<0, hip_block_y_loop, // direction
+              For<2, hip_thread_x_loop, // group
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >
@@ -423,9 +423,9 @@ struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<0, hip_block_x_loop, // Direction
+          For<3, hip_block_x_loop, // zone
             For<2, hip_block_y_loop, // group
-              For<3, hip_thread_x_loop, // zone
+              For<0, hip_thread_x_loop, // direction
                 For<1, seq_exec, // Moment
                   Lambda<0>
                 >

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -208,10 +208,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
       CudaKernelAsync<
-        For<2, cuda_block_x_loop, // group
-          For<0, cuda_block_y_loop, // moment
-            For<3, cuda_thread_x_loop, // zone
-              For<1, seq_exec, // direction
+        For<0, cuda_block_x_loop, // moment
+          For<1, cuda_block_y_loop, // direction
+            For<2, cuda_thread_x_loop, // group
+              For<3, seq_exec, // zone
                 Lambda<0>
               >
             >
@@ -226,10 +226,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
+          For<0, cuda_block_x_loop, // moment
+            For<1, cuda_block_y_loop, // direction
               For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -246,8 +246,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
         CudaKernelAsync<
           For<2, cuda_block_x_loop, // group
             For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, cuda_thread_x_loop, // direction
+                For<3, seq_exec, // zone
                   Lambda<0>
                 >
               >
@@ -263,8 +263,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
       KernelPolicy<
         CudaKernelAsync<
           For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
+            For<3, cuda_block_y_loop, // zone
+              For<0, cuda_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -280,10 +280,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<2, cuda_block_x_loop, // group
+          For<3, cuda_block_x_loop, // zone
             For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, cuda_thread_x_loop, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -298,9 +298,9 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         CudaKernelAsync<
-          For<2, cuda_block_x_loop, // group
-            For<0, cuda_block_y_loop, // moment
-              For<3, cuda_thread_x_loop, // zone
+          For<3, cuda_block_x_loop, // zone
+            For<2, cuda_block_y_loop, // group
+              For<0, cuda_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -319,10 +319,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
       HipKernelAsync<
-        For<2, hip_block_x_loop, // group
-          For<0, hip_block_y_loop, // moment
-            For<3, hip_thread_x_loop, // zone
-              For<1, seq_exec, // direction
+        For<0, hip_block_x_loop, // moment
+          For<1, hip_block_y_loop, // direction
+            For<2, hip_thread_x_loop, // group
+              For<3, seq_exec, // zone
                 Lambda<0>
               >
             >
@@ -337,10 +337,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
+          For<0, hip_block_x_loop, // moment
+            For<1, hip_block_y_loop, // direction
               For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -357,8 +357,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
         HipKernelAsync<
           For<2, hip_block_x_loop, // group
             For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, hip_thread_x_loop, // direction
+                For<3, seq_exec, // zone
                   Lambda<0>
                 >
               >
@@ -374,8 +374,8 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
       KernelPolicy<
         HipKernelAsync<
           For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
+            For<3, hip_block_y_loop, // zone
+              For<0, hip_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >
@@ -391,10 +391,10 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<2, hip_block_x_loop, // group
+          For<3, hip_block_x_loop, // zone
             For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
-                For<1, seq_exec, // direction
+              For<1, hip_thread_x_loop, // direction
+                For<2, seq_exec, // group
                   Lambda<0>
                 >
               >
@@ -409,9 +409,9 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
         HipKernelAsync<
-          For<2, hip_block_x_loop, // group
-            For<0, hip_block_y_loop, // moment
-              For<3, hip_thread_x_loop, // zone
+          For<3, hip_block_x_loop, // zone
+            For<2, hip_block_y_loop, // group
+              For<0, hip_thread_x_loop, // moment
                 For<1, seq_exec, // direction
                   Lambda<0>
                 >

--- a/src/Kripke/Arch/SweepSubdomains.h
+++ b/src/Kripke/Arch/SweepSubdomains.h
@@ -248,13 +248,13 @@ struct Policy_SweepSubdomains<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
           KernelPolicy<
             CudaKernelAsync<
-              For<0, cuda_block_x_loop,
-                For<1, cuda_block_y_loop,
+              For<0, cuda_block_x_loop, // direction
+                For<1, cuda_block_y_loop, // group
 
-                  For<3, cuda_thread_syncable_y_loop,
-                    For<4, cuda_thread_syncable_x_loop,
+                  For<3, cuda_thread_syncable_y_loop, // j
+                    For<4, cuda_thread_syncable_x_loop, // i
                       Hyperplane<
-                        2, seq_exec, ArgList<3, 4>,
+                        2, seq_exec, ArgList<3, 4>, // k
 
                         Lambda<0>,
                         CudaSyncThreads
@@ -405,13 +405,13 @@ struct Policy_SweepSubdomains<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
           KernelPolicy<
             HipKernelAsync<
-              For<0, hip_block_x_loop,
-                For<1, hip_block_y_loop,
+              For<0, hip_block_x_loop,  // direction
+                For<1, hip_block_y_loop,  // group
 
-                  For<3, hip_thread_syncable_y_loop,
-                    For<4, hip_thread_syncable_x_loop,
+                  For<3, hip_thread_syncable_y_loop,  // j
+                    For<4, hip_thread_syncable_x_loop,  // i
                       Hyperplane<
-                        2, seq_exec, ArgList<3, 4>,
+                        2, seq_exec, ArgList<3, 4>, // k
 
                         Lambda<0>,
                         HipSyncThreads


### PR DESCRIPTION
Fix kernel policy loop orderings to match their layout policies. Added clarifying comments on the single sweep loop ordering.