### PR TITLE
Remove Non-Sweep Async

### DIFF
--- a/host-configs/llnl-toss4-MI300A-rocm6-adams.cmake
+++ b/host-configs/llnl-toss4-MI300A-rocm6-adams.cmake
@@ -22,6 +22,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g" CACHE STRING "")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,/opt/cray/pe/cce/20.0.2/cce/x86_64/lib -L/opt/cray/pe/cce/20.0.2/cce/x86_64/lib" CACHE STRING "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
+set(ROCM_PATH "/opt/rocm-6.4.3" CACHE PATH "")
 set(HIP_ROOT_DIR "/opt/rocm-6.4.3/hip" CACHE PATH "")
 set(HIP_PATH "/opt/rocm-6.4.3/llvm/bin" CACHE PATH "")
 set(CMAKE_HIP_ARCHITECTURES "gfx942" CACHE STRING "")

--- a/src/Kripke/Arch/LPlusTimes.h
+++ b/src/Kripke/Arch/LPlusTimes.h
@@ -213,7 +213,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_block_x_loop, // Direction
           For<2, cuda_block_y_loop, // group
             For<3, cuda_thread_x_loop, // zone
@@ -231,7 +231,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // Direction
             For<3, cuda_block_y_loop, // zone
               For<2, cuda_thread_x_loop, // group
@@ -249,7 +249,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<2, cuda_block_x_loop, // group
             For<0, cuda_block_y_loop, // direction
               For<3, cuda_thread_x_loop, // zone
@@ -268,7 +268,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<2, cuda_block_x_loop, // group
             For<3, cuda_block_y_loop, // zone
               For<0, cuda_thread_x_loop, // direction
@@ -286,7 +286,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<3, cuda_block_x_loop, // zone
             For<0, cuda_block_y_loop, // direction
               For<2, cuda_thread_x_loop, // group
@@ -306,7 +306,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<3, cuda_block_x_loop, // zone
             For<2, cuda_block_y_loop, // group
               For<0, cuda_thread_x_loop, // direction
@@ -329,7 +329,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<0, hip_block_x_loop, // Direction
           For<2, hip_block_y_loop, // group
             For<3, hip_thread_x_loop, // zone
@@ -347,7 +347,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // Direction
             For<3, hip_block_y_loop, // zone
               For<2, hip_thread_x_loop, // group
@@ -365,7 +365,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<2, hip_block_x_loop, // group
             For<0, hip_block_y_loop, // direction
               For<3, hip_thread_x_loop, // zone
@@ -384,7 +384,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<2, hip_block_x_loop, // group
             For<3, hip_block_y_loop, // zone
               For<0, hip_thread_x_loop, // direction
@@ -402,7 +402,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<3, hip_block_x_loop, // zone
             For<0, hip_block_y_loop, // direction
               For<2, hip_thread_x_loop, // group
@@ -422,7 +422,7 @@ template<>
 struct Policy_LPlusTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<3, hip_block_x_loop, // zone
             For<2, hip_block_y_loop, // group
               For<0, hip_thread_x_loop, // direction

--- a/src/Kripke/Arch/LTimes.h
+++ b/src/Kripke/Arch/LTimes.h
@@ -207,7 +207,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_block_x_loop, // moment
           For<1, cuda_block_y_loop, // direction
             For<2, cuda_thread_x_loop, // group
@@ -225,7 +225,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // direction
               For<3, cuda_thread_x_loop, // zone
@@ -241,13 +241,14 @@ struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
 
 template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
+    // GZD for correctness on the GPU.
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<2, cuda_block_x_loop, // group
             For<0, cuda_block_y_loop, // moment
-              For<1, cuda_thread_x_loop, // direction
-                For<3, seq_exec, // zone
+              For<3, cuda_thread_x_loop, // zone
+                For<1, seq_exec, // direction
                   Lambda<0>
                 >
               >
@@ -261,7 +262,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<2, cuda_block_x_loop, // group
             For<3, cuda_block_y_loop, // zone
               For<0, cuda_thread_x_loop, // moment
@@ -279,7 +280,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<3, cuda_block_x_loop, // zone
             For<0, cuda_block_y_loop, // moment
               For<1, cuda_thread_x_loop, // direction
@@ -297,7 +298,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<3, cuda_block_x_loop, // zone
             For<2, cuda_block_y_loop, // group
               For<0, cuda_thread_x_loop, // moment
@@ -318,7 +319,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<0, hip_block_x_loop, // moment
           For<1, hip_block_y_loop, // direction
             For<2, hip_thread_x_loop, // group
@@ -336,7 +337,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // direction
               For<3, hip_thread_x_loop, // zone
@@ -352,13 +353,14 @@ struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
 
 template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
+    // GZD for correctness on the GPU.
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<2, hip_block_x_loop, // group
             For<0, hip_block_y_loop, // moment
-              For<1, hip_thread_x_loop, // direction
-                For<3, seq_exec, // zone
+              For<3, hip_thread_x_loop, // zone
+                For<1, seq_exec, // direction
                   Lambda<0>
                 >
               >
@@ -372,7 +374,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<2, hip_block_x_loop, // group
             For<3, hip_block_y_loop, // zone
               For<0, hip_thread_x_loop, // moment
@@ -390,7 +392,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<3, hip_block_x_loop, // zone
             For<0, hip_block_y_loop, // moment
               For<1, hip_thread_x_loop, // direction
@@ -408,7 +410,7 @@ template<>
 struct Policy_LTimes<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<3, hip_block_x_loop, // zone
             For<2, hip_block_y_loop, // group
               For<0, hip_thread_x_loop, // moment

--- a/src/Kripke/Arch/Population.h
+++ b/src/Kripke/Arch/Population.h
@@ -215,7 +215,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_thread_z_loop, // direction
           For<1, cuda_thread_y_loop, // group
             For<2, cuda_threadblock_x_direct, // zone, in blocks of 32 zones
@@ -234,7 +234,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_thread_z_loop, // direction
           For<2, cuda_threadblock_y_direct, // zone, in blocks of 32 zones
             For<1, cuda_thread_x_loop, // group
@@ -253,7 +253,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<1, cuda_thread_z_loop, // group
           For<0, cuda_thread_y_loop, // direction
             For<2, cuda_threadblock_x_direct, // zone, in blocks of 32 zones
@@ -273,7 +273,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<1, cuda_thread_z_loop, // group
           For<2, cuda_threadblock_y_direct, // zone, in blocks of 32 zones
             For<0, cuda_thread_x_loop, // direction
@@ -292,7 +292,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<2, cuda_threadblock_z_direct, // zone, in blocks of 32 zones
           For<0, cuda_thread_y_loop, // direction
             For<1, cuda_thread_x_loop, // group
@@ -310,7 +310,7 @@ struct Policy_Population<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>>{
 
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<2, cuda_threadblock_z_direct, // zone, in blocks of 32 zones
           For<1, cuda_thread_y_loop, // group
             For<0, cuda_thread_x_loop, // direction
@@ -332,7 +332,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<0, hip_thread_z_loop, // direction
           For<1, hip_thread_y_loop, // group
             For<2, hip_threadblock_x_direct, // zone, in blocks of 32 zones
@@ -350,7 +350,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_DZG>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
             For<0, hip_thread_z_loop, // direction
               For<2, hip_threadblock_y_direct, // zone, in blocks of 32 zones
                 For<1, hip_thread_x_loop, // group
@@ -369,7 +369,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<1, hip_thread_z_loop, // group
           For<0, hip_thread_y_loop, // direction
             For<2, hip_threadblock_x_direct, // zone, in blocks of 32 zones
@@ -389,7 +389,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_GZD>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<1, hip_thread_z_loop, // group
           For<2, hip_threadblock_y_direct, // zone, in blocks of 32 zones
             For<0, hip_thread_x_loop, // direction
@@ -408,7 +408,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<2, hip_threadblock_z_direct, // zone, in blocks of 32 zones
           For<0, hip_thread_y_loop, // direction
             For<1, hip_thread_x_loop, // group
@@ -426,7 +426,7 @@ struct Policy_Population<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>>{
 
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<2, hip_threadblock_z_direct, // zone, in blocks of 32 zones
           For<1, hip_thread_y_loop, // group
             For<0, hip_thread_x_loop, // direction

--- a/src/Kripke/Arch/Scattering.h
+++ b/src/Kripke/Arch/Scattering.h
@@ -211,7 +211,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_block_x_loop, // moment
           For<1, cuda_block_y_loop, // DstGrp
             For<3, cuda_thread_x_loop, // zone
@@ -229,7 +229,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // DstGrp
               For<3, cuda_thread_x_loop, // zone
@@ -248,7 +248,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // DstGrp
               For<3, cuda_thread_x_loop, // zone
@@ -267,7 +267,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // DstGrp
               For<3, cuda_thread_x_loop, // zone
@@ -286,7 +286,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // DstGrp
               For<3, cuda_thread_x_loop, // zone
@@ -305,7 +305,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_CUDA, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        CudaKernelAsync<
+        CudaKernel<
           For<0, cuda_block_x_loop, // moment
             For<1, cuda_block_y_loop, // DstGrp
               For<3, cuda_thread_x_loop, // zone
@@ -326,7 +326,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<0, hip_block_x_loop, // moment
           For<1, hip_block_y_loop, // DstGrp
             For<3, hip_thread_x_loop, // zone
@@ -344,7 +344,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // DstGrp
               For<3, hip_thread_x_loop, // zone
@@ -363,7 +363,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_GDZ>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // DstGrp
               For<3, hip_thread_x_loop, // zone
@@ -382,7 +382,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_GZD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // DstGrp
               For<3, hip_thread_x_loop, // zone
@@ -401,7 +401,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_ZDG>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // DstGrp
               For<3, hip_thread_x_loop, // zone
@@ -420,7 +420,7 @@ template<>
 struct Policy_Scattering<ArchLayoutT<ArchT_HIP, LayoutT_ZGD>> {
     using ExecPolicy =
       KernelPolicy<
-        HipKernelAsync<
+        HipKernel<
           For<0, hip_block_x_loop, // moment
             For<1, hip_block_y_loop, // DstGrp
               For<3, hip_thread_x_loop, // zone

--- a/src/Kripke/Arch/Source.h
+++ b/src/Kripke/Arch/Source.h
@@ -84,7 +84,7 @@ template<>
 struct Policy_Source<ArchLayoutT<ArchT_CUDA, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<0, cuda_thread_y_loop,  // Group
           For<1, cuda_threadblock_x_direct, // MixElem, in blocks of 32 MixElem
             Lambda<0>
@@ -98,7 +98,7 @@ template<>
 struct Policy_Source<ArchLayoutT<ArchT_CUDA, LayoutT_DZG>> {
   using ExecPolicy =
     KernelPolicy<
-      CudaKernelAsync<
+      CudaKernel<
         For<1, cuda_threadblock_y_direct, // MixElem, in blocks of 32 MixElem
           For<0, cuda_thread_x_loop,  // Group
             Lambda<0>
@@ -115,7 +115,7 @@ template<>
 struct Policy_Source<ArchLayoutT<ArchT_HIP, LayoutT_DGZ>> {
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<0, hip_thread_y_loop,  // Group
           For<1, hip_threadblock_x_direct, // MixElem, in blocks of 32 MixElem
             Lambda<0>
@@ -129,7 +129,7 @@ template<>
 struct Policy_Source<ArchLayoutT<ArchT_HIP, LayoutT_DZG>> {
   using ExecPolicy =
     KernelPolicy<
-      HipKernelAsync<
+      HipKernel<
         For<1, hip_threadblock_y_direct, // MixElem, in blocks of 32 MixElem
           For<0, hip_thread_x_loop,  // Group
             Lambda<0>


### PR DESCRIPTION
Removes asynchronous GPU kernel calls for non-sweep kernels.

For LTimes, use the GZD loop ordering for the GDZ memory layout. This solves correctness issues with better performance than the use of atomics on MI300A.

Added `ROCM_PATH` to MI300A host-config for Caliper.