### PR TITLE
DRAFT: Staged MPI DO NOT MERGE

### DIFF
--- a/cmake/kripke/CMakeLists.txt
+++ b/cmake/kripke/CMakeLists.txt
@@ -143,6 +143,18 @@ if(ENABLE_CHAI)
 
   # Set camp backends
   if (ENABLE_CUDA)
+    if(ENABLE_CHAI_SINGLE_MEMORY)
+        set (CHAI_ENABLE_UM OFF CACHE BOOL "")
+        set (CHAI_ENABLE_PINNED ON CACHE BOOL "")
+        set(CHAI_DISABLE_RM ON CACHE BOOL "")
+        set(CHAI_THIN_GPU_ALLOCATE ON CACHE BOOL "")
+
+        set(KRIPKE_USE_CHAI_SINGLE_MEMORY 1)
+        if(ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI)
+          set(KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI 1)
+        endif()
+    endif()
+
     message(STATUS "Kripke: Setting CAMP_HAVE_CUDA")
     blt_add_target_definitions(TO camp
                                SCOPE INTERFACE

--- a/cmake/kripke/CMakeLists.txt
+++ b/cmake/kripke/CMakeLists.txt
@@ -107,6 +107,14 @@ endif()
 # 
 option(ENABLE_CHAI "Enable CHAI/Umpire memory management" Off)
 option(ENABLE_CHAI_SINGLE_MEMORY "Enable single memory configuration in CHAI" Off)
+option(ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI
+       "Allocate all CHAI single-memory fields in GPU space and pass GPU pointers to MPI" Off)
+if(ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI AND NOT ENABLE_CHAI_SINGLE_MEMORY)
+  message(FATAL_ERROR "ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI requires ENABLE_CHAI_SINGLE_MEMORY")
+endif()
+if(ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI AND NOT ENABLE_CHAI)
+  message(FATAL_ERROR "ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI requires ENABLE_CHAI")
+endif()
 if(ENABLE_CHAI)
   # Find camp
   if (NOT TARGET camp)
@@ -143,16 +151,20 @@ if(ENABLE_CHAI)
 
   if (ENABLE_HIP)
     if(ENABLE_CHAI_SINGLE_MEMORY)
-        # Set CHAI-related HIP variables for single memory address space.
-        # Use the THIN_GPU_ALLOCATE mode of CHAI on MI250X.
-        # This is to mirror the expected behavior of El Capitan.
-        # Requires env variables HSA_XNACK set to 1 and MPICH_GPU_SUPPORT_ENABLED set to 1 to work on the MI250X.
+        # Set CHAI-related HIP variables for a thin single-memory address space.
+        # By default Kripke keeps CPU-only metadata on the host, GPU compute
+        # fields on the device, and stages remote MPI plane traffic through CPU
+        # buffers. ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI keeps all fields on
+        # the GPU and requires GPU-aware MPI from the runtime.
         set (CHAI_ENABLE_UM OFF CACHE BOOL "")
         set (CHAI_ENABLE_PINNED ON CACHE BOOL "")
         set(CHAI_DISABLE_RM ON CACHE BOOL "")
         set(CHAI_THIN_GPU_ALLOCATE ON CACHE BOOL "")
 
         set(KRIPKE_USE_CHAI_SINGLE_MEMORY 1)
+        if(ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI)
+          set(KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI 1)
+        endif()
     endif()
 
     message(STATUS "Kripke: Setting CAMP_HAVE_HIP")
@@ -409,4 +421,3 @@ blt_add_executable(
   SOURCES     "${KRIPKE_SOURCE_DIR}/src/kripke.cpp"
   DEPENDS_ON  ${KRIPKE_DEPENDS} kripke 
 )
-

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -44,7 +44,7 @@ namespace Core {
 
       explicit FieldStorage(Kripke::Core::Set const &spanned_set
 #ifdef KRIPKE_USE_CHAI
-#ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
+#ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI
           , chai::ExecutionSpace allocation_space = chai::GPU
 #else
           , chai::ExecutionSpace allocation_space = chai::CPU
@@ -342,7 +342,12 @@ namespace Core {
         LType layout = RAJA::make_stride_one<LInfo::stride_one_dim>(m_chunk_to_layout[chunk_id]);
 
 #if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_CHAI)
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::GPU), layout);
+        if(Parent::m_allocation_space == chai::GPU){
+          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(
+              Parent::m_chunk_to_data[chunk_id].data(chai::GPU), layout);
+        }
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(
+            Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
 #else
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id], layout);
 #endif

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -215,16 +215,28 @@ namespace Core {
 #ifdef KRIPKE_USE_CHAI
       chai::ExecutionSpace m_allocation_space;
 #endif
-	  };
+  };
+
+  struct DefaultFieldTag {};
+
+  template<typename TAG, bool HOST_RESIDENT_SINGLE_MEMORY = false>
+  struct FieldPolicy {
+    using Tag = TAG;
+    static constexpr bool host_resident_single_memory =
+        HOST_RESIDENT_SINGLE_MEMORY;
+  };
+
+  using DefaultFieldPolicy = FieldPolicy<DefaultFieldTag, false>;
 
   /**
-   * Defines a multi-dimensional data field defined over a Set
+   * Defines a multi-dimensional data field defined over a Set.
    */
-  template<typename ELEMENT, typename ... IDX_TYPES>
-  class Field : public Kripke::Core::FieldStorage<ELEMENT> {
+  template<typename ELEMENT, typename FIELD_POLICY, typename ... IDX_TYPES>
+  class FieldImpl : public Kripke::Core::FieldStorage<ELEMENT> {
     public:
 
       using Parent = Kripke::Core::FieldStorage<ELEMENT>;
+      using Policy = FIELD_POLICY;
 
       using ElementType = ELEMENT;
 #ifndef KRIPKE_USE_CHAI
@@ -234,6 +246,8 @@ namespace Core {
 #endif
 
       static constexpr size_t NumDims = sizeof...(IDX_TYPES);
+      static constexpr bool host_resident_single_memory =
+          Policy::host_resident_single_memory;
 
       using DefaultLayoutType = RAJA::TypedLayout<RAJA::Index_type, camp::tuple<IDX_TYPES...>>;
 
@@ -242,7 +256,7 @@ namespace Core {
       using DeviceViewType = RAJA::internal::ViewBase<ElementType, ElementType *, DefaultLayoutType>;
 
       template<typename Order>
-      Field(Kripke::Core::Set const &spanned_set, Order) :
+      FieldImpl(Kripke::Core::Set const &spanned_set, Order) :
         Parent(spanned_set)
       {
         setupLayouts<Order>(spanned_set);
@@ -250,7 +264,7 @@ namespace Core {
 
 #ifdef KRIPKE_USE_CHAI
       template<typename Order>
-      Field(Kripke::Core::Set const &spanned_set,
+      FieldImpl(Kripke::Core::Set const &spanned_set,
             chai::ExecutionSpace allocation_space,
             Order) :
         Parent(spanned_set, allocation_space)
@@ -286,7 +300,7 @@ namespace Core {
         }
       }
 
-      virtual ~Field(){
+      virtual ~FieldImpl(){
 
       }
 
@@ -389,6 +403,27 @@ namespace Core {
 
     protected:
       std::vector<DefaultLayoutType> m_chunk_to_layout;
+  };
+
+  template<typename ELEMENT, typename ... IDX_TYPES>
+  class Field : public FieldImpl<ELEMENT, DefaultFieldPolicy, IDX_TYPES...> {
+    public:
+      using Parent = FieldImpl<ELEMENT, DefaultFieldPolicy, IDX_TYPES...>;
+      using Parent::Parent;
+  };
+
+  template<typename ELEMENT, typename FIELD_TAG, bool HOST_RESIDENT_SINGLE_MEMORY,
+           typename ... IDX_TYPES>
+  class Field<ELEMENT,
+              FieldPolicy<FIELD_TAG, HOST_RESIDENT_SINGLE_MEMORY>,
+              IDX_TYPES...> :
+      public FieldImpl<ELEMENT,
+                       FieldPolicy<FIELD_TAG, HOST_RESIDENT_SINGLE_MEMORY>,
+                       IDX_TYPES...> {
+    public:
+      using Policy = FieldPolicy<FIELD_TAG, HOST_RESIDENT_SINGLE_MEMORY>;
+      using Parent = FieldImpl<ELEMENT, Policy, IDX_TYPES...>;
+      using Parent::Parent;
   };
 
 } } // namespace

--- a/src/Kripke/Core/PartitionSpace.h
+++ b/src/Kripke/Core/PartitionSpace.h
@@ -92,11 +92,27 @@ class PartitionSpace : public Kripke::Core::BaseVar {
 template<typename ELEMENT, typename ... IDX_TYPES>
 class Field;
 
+template<typename TAG, bool HOST_RESIDENT_SINGLE_MEMORY>
+struct FieldPolicy;
+
 } // namespace Core
 
-using Field_SdomId2GlobalSdomId = Kripke::Core::Field<GlobalSdomId, SdomId>;
-using Field_GlobalSdomId2Rank = Kripke::Core::Field<long, GlobalSdomId>;
-using Field_GlobalSdomId2SdomId = Kripke::Core::Field<SdomId, GlobalSdomId>;
+struct FieldTag_SdomId2GlobalSdomId {};
+struct FieldTag_GlobalSdomId2Rank {};
+struct FieldTag_GlobalSdomId2SdomId {};
+
+using Field_SdomId2GlobalSdomId =
+    Kripke::Core::Field<GlobalSdomId,
+                        Kripke::Core::FieldPolicy<FieldTag_SdomId2GlobalSdomId, true>,
+                        SdomId>;
+using Field_GlobalSdomId2Rank =
+    Kripke::Core::Field<long,
+                        Kripke::Core::FieldPolicy<FieldTag_GlobalSdomId2Rank, true>,
+                        GlobalSdomId>;
+using Field_GlobalSdomId2SdomId =
+    Kripke::Core::Field<SdomId,
+                        Kripke::Core::FieldPolicy<FieldTag_GlobalSdomId2SdomId, true>,
+                        GlobalSdomId>;
 
 
 } // namespace

--- a/src/Kripke/Generate/Quadrature.cpp
+++ b/src/Kripke/Generate/Quadrature.cpp
@@ -376,10 +376,10 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
   auto &field_ycos = createField<Field_Direction2Double>(data_store, "quadrature/ycos", al_v, *dir_set);
   auto &field_zcos = createField<Field_Direction2Double>(data_store, "quadrature/zcos", al_v, *dir_set);
   auto &field_w = createField<Field_Direction2Double>(data_store, "quadrature/w", al_v, *dir_set);
-  auto &field_id = createField<Field_Direction2Int>(data_store, "quadrature/id", al_v, *dir_set);
-  auto &field_jd = createField<Field_Direction2Int>(data_store, "quadrature/jd", al_v, *dir_set);
-  auto &field_kd = createField<Field_Direction2Int>(data_store, "quadrature/kd", al_v, *dir_set);
-  auto &field_octant = createField<Field_Direction2Int>(data_store, "quadrature/octant", al_v, *dir_set);
+  auto &field_id = createField<Field_QuadratureDirectionSign>(data_store, "quadrature/id", al_v, *dir_set);
+  auto &field_jd = createField<Field_QuadratureDirectionSign>(data_store, "quadrature/jd", al_v, *dir_set);
+  auto &field_kd = createField<Field_QuadratureDirectionSign>(data_store, "quadrature/kd", al_v, *dir_set);
+  auto &field_octant = createField<Field_QuadratureOctant>(data_store, "quadrature/octant", al_v, *dir_set);
 
   for(SdomId sdom_id : field_xcos.getWorkList()){
     int num_directions = dir_set->size(sdom_id);
@@ -473,7 +473,7 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
     // Offset local coordinate to global coordinates
     auto global_coord = pspace.coordToGlobalCoord(local_coord);
 
-    std::array<Field_Direction2Int::DefaultViewType, 3> sweep_dir =
+    std::array<Field_QuadratureDirectionSign::DefaultViewType, 3> sweep_dir =
         {{
           field_id.getView(sdom_id),
           field_jd.getView(sdom_id),
@@ -517,5 +517,4 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
 
   }
 }
-
 

--- a/src/Kripke/Generate/Quadrature.cpp
+++ b/src/Kripke/Generate/Quadrature.cpp
@@ -38,6 +38,49 @@ namespace {
     int octant;
   };
 
+#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  template<typename T>
+  T *copyVectorToDevice(std::vector<T> const &src)
+  {
+    if(src.empty()){
+      return nullptr;
+    }
+
+    T *dst = nullptr;
+#if defined(KRIPKE_USE_CUDA)
+    cudaError_t err = cudaMalloc((void **)&dst, src.size() * sizeof(T));
+    KRIPKE_ASSERT(err == cudaSuccess,
+        "cudaMalloc failed: %s\n", cudaGetErrorString(err));
+    err = cudaMemcpy(dst, src.data(), src.size() * sizeof(T),
+        cudaMemcpyHostToDevice);
+    KRIPKE_ASSERT(err == cudaSuccess,
+        "cudaMemcpy host-to-device failed: %s\n", cudaGetErrorString(err));
+#else
+    hipError_t err = hipMalloc((void **)&dst, src.size() * sizeof(T));
+    KRIPKE_ASSERT(err == hipSuccess,
+        "hipMalloc failed: %s\n", hipGetErrorString(err));
+    err = hipMemcpy(dst, src.data(), src.size() * sizeof(T),
+        hipMemcpyHostToDevice);
+    KRIPKE_ASSERT(err == hipSuccess,
+        "hipMemcpy host-to-device failed: %s\n", hipGetErrorString(err));
+#endif
+    return dst;
+  }
+
+  template<typename T>
+  void freeDevice(T *ptr)
+  {
+    if(ptr == nullptr){
+      return;
+    }
+#if defined(KRIPKE_USE_CUDA)
+    cudaFree(ptr);
+#else
+    hipFree(ptr);
+#endif
+  }
+#endif
+
 
   /*
     GaussLegendre returns the n point Gauss-Legendre quadrature rule for
@@ -80,7 +123,7 @@ namespace {
     return b.octant < a.octant;
   }
 
-  double FactFcn(int n)
+  RAJA_HOST_DEVICE inline double FactFcn(int n)
   {
     double fact = 1.0;
     for(int i = n;i > 0 ;--i){
@@ -89,7 +132,7 @@ namespace {
     return(fact);
   }
 
-  inline double PnmFcn(int n, int m, double x)
+  RAJA_HOST_DEVICE inline double PnmFcn(int n, int m, double x)
   {
     /*-----------------------------------------------------------------
      * It is assumed that 0 <= m <= n and that abs(x) <= 1.0.
@@ -99,13 +142,15 @@ namespace {
 
     int i, nn;
 
-    if(std::abs(x) > 1.0){
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+    if(fabs(x) > 1.0){
       KRIPKE_ABORT("Bad input to PnmFcn: abs(x) > 1.0, x = %e\n", x);
     }
-    else if((x > 1.0) && (x <= 1.0)){
+#endif
+    if(x > 1.0){
       x = 1.0;
     }
-    else if((-1.0 <= x ) && (x < -1.0)){
+    else if(x < -1.0){
       x = -1.0;
     }
 
@@ -137,7 +182,7 @@ namespace {
     }
   }
 
-  inline double YnmFcn(int n, int m, double mu, double eta, double xi)
+  RAJA_HOST_DEVICE inline double YnmFcn(int n, int m, double mu, double eta, double xi)
   {
     double fac1, fac2, anm, ynm, pnm, dm0, taum, tmp, phi, phi_tmp;
     double floor=1.e-20;
@@ -160,11 +205,12 @@ namespace {
     }
 
     /* Begin evaluation of Ynm(omega) */
-    nn = n - std::abs(m);
+    int abs_m = (m < 0) ? -m : m;
+    nn = n - abs_m;
     fac1 = (double) FactFcn(nn);
-    nn = n + std::abs(m);
+    nn = n + abs_m;
     fac2 = (double) FactFcn(nn);
-    mm = std::abs(m);
+    mm = abs_m;
     pnm = PnmFcn(n, mm, xi);
     tmp = ((double) m)*phi;
     if(m >= 0){
@@ -358,13 +404,8 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
 
   // fill in the global
   for(SdomId sdom_id : field_moment_to_legendre.getWorkList()){
-    auto moment_to_legendre = field_moment_to_legendre.getView(sdom_id);
-
-    RAJA::forall<RAJA::seq_exec>(
-      RAJA::TypedRangeSegment<Moment>(0, moment_set->size(sdom_id)),
-      [=](Moment nm){
-        moment_to_legendre(nm) = moment_list[(*nm) + moment_set->lower(sdom_id)];
-    });
+    Kripke::Kernel::kCopyHostToField(field_moment_to_legendre, sdom_id,
+        moment_list.data() + moment_set->lower(sdom_id));
   }
 
 
@@ -385,28 +426,35 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
     int num_directions = dir_set->size(sdom_id);
     int direction_lower = dir_set->lower(sdom_id);
 
-    auto xcos = field_xcos.getView(sdom_id);
-    auto ycos = field_ycos.getView(sdom_id);
-    auto zcos = field_zcos.getView(sdom_id);
-    auto w = field_w.getView(sdom_id);
-    auto id = field_id.getView(sdom_id);
-    auto jd = field_jd.getView(sdom_id);
-    auto kd = field_kd.getView(sdom_id);
-    auto octant = field_octant.getView(sdom_id);
+    std::vector<double> xcos(num_directions);
+    std::vector<double> ycos(num_directions);
+    std::vector<double> zcos(num_directions);
+    std::vector<double> w(num_directions);
+    std::vector<int> id(num_directions);
+    std::vector<int> jd(num_directions);
+    std::vector<int> kd(num_directions);
+    std::vector<int> octant(num_directions);
 
-    RAJA::forall<RAJA::seq_exec>(
-      RAJA::TypedRangeSegment<Direction>(0, num_directions),
-      [=](Direction d){
-      QuadraturePoint const &point_d = quadrature_points[(*d)+direction_lower];
-      xcos(d) = point_d.xcos;
-      ycos(d) = point_d.ycos;
-      zcos(d) = point_d.zcos;
-      w(d) = point_d.w;
-      id(d) = point_d.id;
-      jd(d) = point_d.jd;
-      kd(d) = point_d.kd;
-      octant(d) = point_d.octant;
-    });
+    for(int d = 0; d < num_directions; ++d){
+      QuadraturePoint const &point_d = quadrature_points[d + direction_lower];
+      xcos[d] = point_d.xcos;
+      ycos[d] = point_d.ycos;
+      zcos[d] = point_d.zcos;
+      w[d] = point_d.w;
+      id[d] = point_d.id;
+      jd[d] = point_d.jd;
+      kd[d] = point_d.kd;
+      octant[d] = point_d.octant;
+    }
+
+    Kripke::Kernel::kCopyHostToField(field_xcos, sdom_id, xcos.data());
+    Kripke::Kernel::kCopyHostToField(field_ycos, sdom_id, ycos.data());
+    Kripke::Kernel::kCopyHostToField(field_zcos, sdom_id, zcos.data());
+    Kripke::Kernel::kCopyHostToField(field_w, sdom_id, w.data());
+    Kripke::Kernel::kCopyHostToField(field_id, sdom_id, id.data());
+    Kripke::Kernel::kCopyHostToField(field_jd, sdom_id, jd.data());
+    Kripke::Kernel::kCopyHostToField(field_kd, sdom_id, kd.data());
+    Kripke::Kernel::kCopyHostToField(field_octant, sdom_id, octant.data());
   }
 
 
@@ -421,38 +469,111 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
   auto &field_ell = createField<Field_Ell>(data_store, "ell", al_v, set_ell);
   auto &field_ell_plus = createField<Field_EllPlus>(data_store, "ell_plus", al_v, set_ell_plus);
 
+#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  QuadraturePoint *quadrature_points_device = nullptr;
+  if(field_ell.getAllocationSpace() == chai::GPU){
+    quadrature_points_device = copyVectorToDevice(quadrature_points);
+  }
+#endif
+
   for(SdomId sdom_id : field_xcos.getWorkList()){
-    auto ell = field_ell.getView(sdom_id);
-    auto ell_plus = field_ell_plus.getView(sdom_id);
+#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+    if(field_ell.getAllocationSpace() == chai::GPU){
+      KRIPKE_ASSERT(field_ell_plus.getAllocationSpace() == chai::GPU,
+          "ell and ell_plus must use the same allocation space");
 
-    int num_directions = dir_set->size(sdom_id);
-    int direction_lower = dir_set->lower(sdom_id);
+      auto ell = field_ell.getDeviceView(sdom_id);
+      auto ell_plus = field_ell_plus.getDeviceView(sdom_id);
 
-    double SQRT4PI = std::sqrt(4*M_PI);
-    Moment nm{0};
-    for(int n=0; n < (int)legendre_order+1; n++){
-      for(int m=-n; m<=n; m++){
-        RAJA::forall<RAJA::seq_exec>(
-          RAJA::TypedRangeSegment<Direction>(0, num_directions),
-          [=](Direction d){
+      int num_directions = dir_set->size(sdom_id);
+      int direction_lower = dir_set->lower(sdom_id);
+      int num_moments_sdom = moment_set->size(sdom_id);
+      int legendre_order_i = legendre_order;
+      double SQRT4PI = sqrt(4*M_PI);
+      QuadraturePoint const *points = quadrature_points_device;
 
-            QuadraturePoint const &point_d = quadrature_points[(*d)+direction_lower];
-            // Get quadrature point info
-            double xcos = (point_d.id)*(point_d.xcos);
-            double ycos = (point_d.jd)*(point_d.ycos);
-            double zcos = (point_d.kd)*(point_d.zcos);
-            double w =  point_d.w;
+#if defined(KRIPKE_USE_CUDA)
+      RAJA::forall<RAJA::cuda_exec<256>>(
+#else
+      RAJA::forall<RAJA::hip_exec<256>>(
+#endif
+        RAJA::RangeSegment(0, num_moments_sdom * num_directions),
+        KRIPKE_LAMBDA (RAJA::Index_type idx){
+          int nm_i = idx / num_directions;
+          int d_i = idx % num_directions;
 
-            double ynm = YnmFcn(n, m, xcos, ycos, zcos);
+          int n = 0;
+          int m = 0;
+          int first_moment = 0;
+          for(int nn = 0; nn <= legendre_order_i; ++nn){
+            int moment_count = 2*nn + 1;
+            if(nm_i < first_moment + moment_count){
+              n = nn;
+              m = nm_i - first_moment - nn;
+              break;
+            }
+            first_moment += moment_count;
+          }
 
-            // Compute element of L and L+
-            ell(nm, d) = w*ynm/SQRT4PI;
-            ell_plus(d,nm) = ynm*SQRT4PI;
-        });
-        nm ++;
+          QuadraturePoint const point_d = points[d_i + direction_lower];
+          double xcos = point_d.id * point_d.xcos;
+          double ycos = point_d.jd * point_d.ycos;
+          double zcos = point_d.kd * point_d.zcos;
+
+          double ynm = YnmFcn(n, m, xcos, ycos, zcos);
+
+          Moment nm{nm_i};
+          Direction d{d_i};
+          ell(nm, d) = point_d.w * ynm / SQRT4PI;
+          ell_plus(d, nm) = ynm * SQRT4PI;
+      });
+    }
+    else
+#endif
+    {
+      auto ell = field_ell.getView(sdom_id);
+      auto ell_plus = field_ell_plus.getView(sdom_id);
+
+      int num_directions = dir_set->size(sdom_id);
+      int direction_lower = dir_set->lower(sdom_id);
+
+      double SQRT4PI = std::sqrt(4*M_PI);
+      Moment nm{0};
+      for(int n=0; n < (int)legendre_order+1; n++){
+        for(int m=-n; m<=n; m++){
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::TypedRangeSegment<Direction>(0, num_directions),
+            [=](Direction d){
+
+              QuadraturePoint const &point_d = quadrature_points[(*d)+direction_lower];
+              // Get quadrature point info
+              double xcos = (point_d.id)*(point_d.xcos);
+              double ycos = (point_d.jd)*(point_d.ycos);
+              double zcos = (point_d.kd)*(point_d.zcos);
+              double w =  point_d.w;
+
+              double ynm = YnmFcn(n, m, xcos, ycos, zcos);
+
+              // Compute element of L and L+
+              ell(nm, d) = w*ynm/SQRT4PI;
+              ell_plus(d,nm) = ynm*SQRT4PI;
+          });
+          nm ++;
+        }
       }
     }
   }
+
+#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  if(quadrature_points_device != nullptr){
+#if defined(KRIPKE_USE_CUDA)
+    RAJA::synchronize<RAJA::cuda_synchronize>();
+#else
+    RAJA::synchronize<RAJA::hip_synchronize>();
+#endif
+    freeDevice(quadrature_points_device);
+  }
+#endif
 
 
   // Create fields to store subdomain adjacency information for boundary comm
@@ -517,4 +638,3 @@ void Kripke::Generate::generateQuadrature(Kripke::Core::DataStore &data_store,
 
   }
 }
-

--- a/src/Kripke/Generate/Space.cpp
+++ b/src/Kripke/Generate/Space.cpp
@@ -271,7 +271,7 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
 
 
   // Populate mixture fields with our dynamic data
-  RAJA::ReduceSum<RAJA::seq_reduce, double> total_volume_red[3];
+  double total_volume_red[3] = {0.0, 0.0, 0.0};
   for(size_t i = 0;i < sdom_list.size();++ i){
     SdomId sdom_id = sdom_list[i];
 
@@ -280,40 +280,47 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
 
     auto const &sdom_mix = mix[i];
 
-    auto mixed_to_zone       = field_mixed_to_zone.getView(sdom_id);
-    auto mixed_to_material   = field_mixed_to_material.getView(sdom_id);
-    auto mixed_to_fraction   = field_mixed_to_fraction.getView(sdom_id);
-    auto zone_to_num_mixelem = field_zone_to_num_mixelem.getView(sdom_id);
-    auto zone_to_mixelem     = field_zone_to_mixelem.getView(sdom_id);
+    std::vector<Zone> mixed_to_zone(num_mixelems);
+    std::vector<Material> mixed_to_material(num_mixelems);
+    std::vector<double> mixed_to_fraction(num_mixelems);
+    std::vector<int> zone_to_num_mixelem(num_zones);
+    std::vector<MixElem> zone_to_mixelem(num_zones);
 
-    RAJA::ReduceSum<RAJA::seq_reduce, MixElem> mixelem(MixElem{0});
-    RAJA::forall<RAJA::seq_exec>(
-      RAJA::TypedRangeSegment<Zone>(0, num_zones),
-      [=](Zone z){
-        ZoneMixture const &zone_mix = sdom_mix[*z];
-        int num_zone_mix = 0;
+    int mixelem = 0;
+    for(Zone z{0}; z < num_zones; ++z){
+      ZoneMixture const &zone_mix = sdom_mix[*z];
+      int num_zone_mix = 0;
 
-        zone_to_mixelem(z) = mixelem;
+      zone_to_mixelem[*z] = MixElem{mixelem};
 
-        double zone_frac = 0.0;
-        for(Material m{0};m < 3;++ m){
-          if(zone_mix.fraction[*m] > 0.0){
-            MixElem me = mixelem;
-
-            mixed_to_zone(me) = z;
-            mixed_to_material(me) = m;
-            mixed_to_fraction(me) = zone_mix.fraction[*m];
-            zone_frac += zone_mix.fraction[*m];
-            total_volume_red[*m] += zone_mix.fraction[*m] * zone_volume;
-            num_zone_mix ++;
-            mixelem += MixElem{1};
-          }
+      double zone_frac = 0.0;
+      for(Material m{0};m < 3;++ m){
+        if(zone_mix.fraction[*m] > 0.0){
+          mixed_to_zone[mixelem] = z;
+          mixed_to_material[mixelem] = m;
+          mixed_to_fraction[mixelem] = zone_mix.fraction[*m];
+          zone_frac += zone_mix.fraction[*m];
+          total_volume_red[*m] += zone_mix.fraction[*m] * zone_volume;
+          num_zone_mix ++;
+          mixelem ++;
         }
-        KRIPKE_ASSERT(zone_frac == 1.0, "Zone fraction wrong: %e", zone_frac);
-        zone_to_num_mixelem(z) = num_zone_mix;
-    });
+      }
+      KRIPKE_ASSERT(zone_frac == 1.0, "Zone fraction wrong: %e", zone_frac);
+      zone_to_num_mixelem[*z] = num_zone_mix;
+    }
 
-    KRIPKE_ASSERT((*((MixElem)mixelem)) == num_mixelems, "Mismatch in mixture info");
+    KRIPKE_ASSERT(mixelem == num_mixelems, "Mismatch in mixture info");
+
+    Kripke::Kernel::kCopyHostToField(field_mixed_to_zone, sdom_id,
+        mixed_to_zone.data());
+    Kripke::Kernel::kCopyHostToField(field_mixed_to_material, sdom_id,
+        mixed_to_material.data());
+    Kripke::Kernel::kCopyHostToField(field_mixed_to_fraction, sdom_id,
+        mixed_to_fraction.data());
+    Kripke::Kernel::kCopyHostToField(field_zone_to_num_mixelem, sdom_id,
+        zone_to_num_mixelem.data());
+    Kripke::Kernel::kCopyHostToField(field_zone_to_mixelem, sdom_id,
+        zone_to_mixelem.data());
   }
 
   // Display the total volume

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -11,10 +11,16 @@
 #include <Kripke.h>
 #include <Kripke/ArchLayout.h>
 #include <Kripke/Core/DataStore.h>
+#include <algorithm>
 #include <utility>
 
 #ifdef KRIPKE_USE_CHAI
 #include <chai/ExecutionSpaces.hpp>
+#endif
+#if defined(KRIPKE_USE_CUDA)
+#include <cuda_runtime.h>
+#elif defined(KRIPKE_USE_HIP)
+#include <hip/hip_runtime.h>
 #endif
 
 namespace Kripke {
@@ -131,6 +137,43 @@ namespace Kripke {
 
 
     void sweepSubdomain(Kripke::Core::DataStore &data_store, Kripke::SdomId sdom_id);
+
+
+    template<typename FieldType>
+    RAJA_INLINE
+    void kCopyHostToField(FieldType &field,
+                          Kripke::SdomId sdom_id,
+                          typename FieldType::ElementType const *src){
+      using ElementType = typename FieldType::ElementType;
+
+      size_t const num_elem = field.size(sdom_id);
+      if(num_elem == 0){
+        return;
+      }
+
+#if defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_CUDA)
+      if(detail::fieldUsesDevice(field)){
+        cudaError_t err = cudaMemcpy(field.getDeviceData(sdom_id), src,
+            num_elem * sizeof(ElementType), cudaMemcpyHostToDevice);
+        KRIPKE_ASSERT(err == cudaSuccess,
+            "cudaMemcpy host-to-device field copy failed: %s\n",
+            cudaGetErrorString(err));
+        return;
+      }
+#elif defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_HIP)
+      if(detail::fieldUsesDevice(field)){
+        hipError_t err = hipMemcpy(field.getDeviceData(sdom_id), src,
+            num_elem * sizeof(ElementType), hipMemcpyHostToDevice);
+        KRIPKE_ASSERT(err == hipSuccess,
+            "hipMemcpy host-to-device field copy failed: %s\n",
+            hipGetErrorString(err));
+        return;
+      }
+#endif
+
+      ElementType *dst = field.getHostData(sdom_id);
+      std::copy(src, src + num_elem, dst);
+    }
 
 
     template<typename FieldType>

--- a/src/Kripke/Kernel/SweepSubdomain.cpp
+++ b/src/Kripke/Kernel/SweepSubdomain.cpp
@@ -40,9 +40,9 @@ struct SweepSdom {
     auto xcos = sdom_al.getView(data_store.getVariable<Field_Direction2Double>("quadrature/xcos"));
     auto ycos = sdom_al.getView(data_store.getVariable<Field_Direction2Double>("quadrature/ycos"));
     auto zcos = sdom_al.getView(data_store.getVariable<Field_Direction2Double>("quadrature/zcos"));
-    auto view_id = data_store.getVariable<Field_Direction2Int>("quadrature/id").getView(sdom_id);
-    auto view_jd = data_store.getVariable<Field_Direction2Int>("quadrature/jd").getView(sdom_id);
-    auto view_kd = data_store.getVariable<Field_Direction2Int>("quadrature/kd").getView(sdom_id);
+    auto view_id = data_store.getVariable<Field_QuadratureDirectionSign>("quadrature/id").getView(sdom_id);
+    auto view_jd = data_store.getVariable<Field_QuadratureDirectionSign>("quadrature/jd").getView(sdom_id);
+    auto view_kd = data_store.getVariable<Field_QuadratureDirectionSign>("quadrature/kd").getView(sdom_id);
 
     auto dx = sdom_al.getView(data_store.getVariable<Field_ZoneI2Double>("dx"));
     auto dy = sdom_al.getView(data_store.getVariable<Field_ZoneJ2Double>("dy"));

--- a/src/Kripke/ParallelComm.cpp
+++ b/src/Kripke/ParallelComm.cpp
@@ -11,7 +11,119 @@
 #include <Kripke/Core/Field.h>
 #include <Kripke/VarTypes.h>
 
+#include <algorithm>
+
+#if defined(KRIPKE_USE_CUDA)
+#include <cuda_runtime.h>
+#elif defined(KRIPKE_USE_HIP)
+#include <hip/hip_runtime.h>
+#endif
+
 using namespace Kripke;
+
+static void synchronizeDevice()
+{
+#if defined(KRIPKE_USE_CUDA)
+  RAJA::synchronize<RAJA::cuda_synchronize>();
+#elif defined(KRIPKE_USE_HIP)
+  RAJA::synchronize<RAJA::hip_synchronize>();
+#endif
+}
+
+static bool mpiNeedsHostStaging(Kripke::Core::FieldStorage<double> const &field)
+{
+#if defined(KRIPKE_USE_CHAI_SINGLE_MEMORY) && defined(KRIPKE_USE_CHAI) && \
+    (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  if(Kripke::singleMemoryGpuAwareMpiMode()){
+    return false;
+  }
+  return field.getAllocationSpace() == chai::GPU;
+#else
+  (void)field;
+  return false;
+#endif
+}
+
+static double *getMpiRecvBuffer(Kripke::Core::FieldStorage<double> &field,
+                                Kripke::SdomId sdom_id)
+{
+#if defined(KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI) && defined(KRIPKE_USE_CHAI) && \
+    (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  if(field.getAllocationSpace() == chai::GPU){
+    return field.getDeviceData(sdom_id);
+  }
+#endif
+
+  return field.getHostData(sdom_id);
+}
+
+static double *getMpiSendBuffer(Kripke::Core::FieldStorage<double> const &field,
+                                Kripke::SdomId sdom_id)
+{
+#if defined(KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI) && defined(KRIPKE_USE_CHAI) && \
+    (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+  if(field.getAllocationSpace() == chai::GPU){
+    synchronizeDevice();
+    return field.getDeviceData(sdom_id);
+  }
+#endif
+
+  return const_cast<double *>(field.getHostDataConst(sdom_id));
+}
+
+static void copyPlaneToHost(double *dst,
+                            Kripke::Core::FieldStorage<double> const &src_plane,
+                            Kripke::SdomId src_sdom_id)
+{
+  size_t const num_elem = src_plane.size(src_sdom_id);
+  size_t const num_bytes = num_elem * sizeof(double);
+
+#if defined(KRIPKE_USE_CHAI_SINGLE_MEMORY) && defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_CUDA)
+  if(src_plane.getAllocationSpace() == chai::GPU){
+    cudaError_t err = cudaMemcpy(dst, src_plane.getDeviceData(src_sdom_id), num_bytes, cudaMemcpyDeviceToHost);
+    KRIPKE_ASSERT(err == cudaSuccess,
+        "cudaMemcpy device-to-host failed: %s\n", cudaGetErrorString(err));
+    return;
+  }
+#elif defined(KRIPKE_USE_CHAI_SINGLE_MEMORY) && defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_HIP)
+  if(src_plane.getAllocationSpace() == chai::GPU){
+    hipError_t err = hipMemcpy(dst, src_plane.getDeviceData(src_sdom_id), num_bytes, hipMemcpyDeviceToHost);
+    KRIPKE_ASSERT(err == hipSuccess,
+        "hipMemcpy device-to-host failed: %s\n", hipGetErrorString(err));
+    return;
+  }
+#endif
+
+  double const *src = src_plane.getHostDataConst(src_sdom_id);
+  std::copy(src, src + num_elem, dst);
+}
+
+static void copyHostToPlane(Kripke::Core::FieldStorage<double> &dst_plane,
+                            Kripke::SdomId dst_sdom_id,
+                            double const *src)
+{
+  size_t const num_elem = dst_plane.size(dst_sdom_id);
+  size_t const num_bytes = num_elem * sizeof(double);
+
+#if defined(KRIPKE_USE_CHAI_SINGLE_MEMORY) && defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_CUDA)
+  if(dst_plane.getAllocationSpace() == chai::GPU){
+    cudaError_t err = cudaMemcpy(dst_plane.getDeviceData(dst_sdom_id), src, num_bytes, cudaMemcpyHostToDevice);
+    KRIPKE_ASSERT(err == cudaSuccess,
+        "cudaMemcpy host-to-device failed: %s\n", cudaGetErrorString(err));
+    return;
+  }
+#elif defined(KRIPKE_USE_CHAI_SINGLE_MEMORY) && defined(KRIPKE_USE_CHAI) && defined(KRIPKE_USE_HIP)
+  if(dst_plane.getAllocationSpace() == chai::GPU){
+    hipError_t err = hipMemcpy(dst_plane.getDeviceData(dst_sdom_id), src, num_bytes, hipMemcpyHostToDevice);
+    KRIPKE_ASSERT(err == hipSuccess,
+        "hipMemcpy host-to-device failed: %s\n", hipGetErrorString(err));
+    return;
+  }
+#endif
+
+  double *dst = dst_plane.getHostData(dst_sdom_id);
+  std::copy(src, src + num_elem, dst);
+}
 
 // Helper for copying plane data between two GPU allocations, only used in ParallelComm
 static void copyPlane(Kripke::Core::FieldStorage<double> &dst_plane,
@@ -132,10 +244,20 @@ void ParallelComm::postRecvs(Kripke::Core::DataStore &data_store, SdomId sdom_id
     // Add request to pending list
     recv_requests.push_back(MPI_Request());
     recv_subdomains.push_back(*sdom_id);
+    recv_dimensions.push_back(*dim);
 
     auto &plane_data = *m_plane_data[*dim];
-    double *plane_data_ptr = plane_data.getHostData(sdom_id);
     size_t plane_data_size = plane_data.size(sdom_id);
+    double *plane_data_ptr = nullptr;
+
+    if(mpiNeedsHostStaging(plane_data)){
+      recv_buffers.push_back(std::make_unique<double[]>(plane_data_size));
+      plane_data_ptr = recv_buffers.back().get();
+    }
+    else{
+      recv_buffers.push_back(nullptr);
+      plane_data_ptr = getMpiRecvBuffer(plane_data, sdom_id);
+    }
 
     GlobalSdomId global_sdom_id = local_to_global(sdom_id);
 
@@ -205,10 +327,19 @@ void ParallelComm::postSends(Kripke::Core::DataStore &data_store, Kripke::SdomId
     // Get size of outgoing boudnary data
     auto &plane_data = *m_plane_data[*dim];
     size_t plane_data_size = plane_data.size(sdom_id);
-    double const *src_buffer = src_plane_data[*dim]->getHostDataConst(sdom_id);
+    double *src_buffer = nullptr;
+
+    if(mpiNeedsHostStaging(*src_plane_data[*dim])){
+      send_buffers.push_back(std::make_unique<double[]>(plane_data_size));
+      src_buffer = send_buffers.back().get();
+      copyPlaneToHost(src_buffer, *src_plane_data[*dim], sdom_id);
+    }
+    else{
+      src_buffer = getMpiSendBuffer(*src_plane_data[*dim], sdom_id);
+    }
 
     // Post the send
-    MPI_Isend(const_cast<double *>(src_buffer), plane_data_size, MPI_DOUBLE, downwind_rank,
+    MPI_Isend(src_buffer, plane_data_size, MPI_DOUBLE, downwind_rank,
       *downwind_sdom, MPI_COMM_WORLD, &send_requests[send_requests.size()-1]);
 
 #else
@@ -239,6 +370,7 @@ void ParallelComm::waitAllSends(void){
     std::vector<MPI_Status> status(num_sends);
     MPI_Waitall(num_sends, &send_requests[0], &status[0]);
     send_requests.clear();
+    send_buffers.clear();
   }
 #endif
 }
@@ -264,10 +396,17 @@ void ParallelComm::testRecieves(void){
 
       // get subdomain that this completed for
       int sdom_id = recv_subdomains[index];
+      int dim = recv_dimensions[index];
+
+      if(recv_buffers[index]){
+        copyHostToPlane(*m_plane_data[dim], SdomId{sdom_id}, recv_buffers[index].get());
+      }
 
       // remove the request from the list
       recv_requests.erase(recv_requests.begin()+index);
       recv_subdomains.erase(recv_subdomains.begin()+index);
+      recv_dimensions.erase(recv_dimensions.begin()+index);
+      recv_buffers.erase(recv_buffers.begin()+index);
       num_requests --;
 
       // decrement the dependency count for that subdomain

--- a/src/Kripke/ParallelComm.h
+++ b/src/Kripke/ParallelComm.h
@@ -9,6 +9,7 @@
 #define KRIPKE_PARALLELCOMM_H__
 
 #include <Kripke.h>
+#include <memory>
 #include <vector>
 
 struct Grid_Data;
@@ -57,6 +58,8 @@ class ParallelComm {
     // These vectors contian the recieve requests
 #ifdef KRIPKE_USE_MPI
     std::vector<MPI_Request> recv_requests;
+    std::vector<std::unique_ptr<double[]>> recv_buffers;
+    std::vector<int> recv_dimensions;
 #endif
     std::vector<int> recv_subdomains;
 
@@ -67,6 +70,7 @@ class ParallelComm {
     // These vectors have the remaining send requests that are incomplete
 #ifdef KRIPKE_USE_MPI
     std::vector<MPI_Request> send_requests;
+    std::vector<std::unique_ptr<double[]>> send_buffers;
 #endif
 };
 

--- a/src/Kripke/SteadyStateSolver.cpp
+++ b/src/Kripke/SteadyStateSolver.cpp
@@ -106,7 +106,7 @@ int Kripke::SteadyStateSolver (Kripke::Core::DataStore &data_store, size_t max_i
      */
     double part = Kripke::Kernel::population(data_store);
     if(comm.rank() == 0){
-      printf("  iter %d: particle count=%.10e, change=%.10e\n", (int)iter, part, (part-part_last)/part);
+      printf("  iter %d: particle count=%.6e, change=%.6e\n", (int)iter, part, (part-part_last)/part);
       fflush(stdout);
     }
     part_last = part;

--- a/src/Kripke/SteadyStateSolver.cpp
+++ b/src/Kripke/SteadyStateSolver.cpp
@@ -106,7 +106,7 @@ int Kripke::SteadyStateSolver (Kripke::Core::DataStore &data_store, size_t max_i
      */
     double part = Kripke::Kernel::population(data_store);
     if(comm.rank() == 0){
-      printf("  iter %d: particle count=%e, change=%e\n", (int)iter, part, (part-part_last)/part);
+      printf("  iter %d: particle count=%.10e, change=%.10e\n", (int)iter, part, (part-part_last)/part);
       fflush(stdout);
     }
     part_last = part;

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -137,10 +137,45 @@ namespace Kripke {
 
 #ifdef KRIPKE_USE_CHAI
   RAJA_INLINE
-  chai::ExecutionSpace fieldAllocationSpace(ArchV arch_v)
+  bool singleMemoryGpuAwareMpiMode()
+  {
+#ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI
+    return true;
+#else
+    return false;
+#endif
+  }
+
+  RAJA_INLINE
+  bool hostResidentSingleMemoryField(std::string const &name)
+  {
+#ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
+    return name == "quadrature/id" ||
+           name == "quadrature/jd" ||
+           name == "quadrature/kd" ||
+           name == "quadrature/octant" ||
+           name == "upwind" ||
+           name == "downwind" ||
+           name == "SdomId2GlobalSdomId" ||
+           name == "GlobalSdomId2SdomId" ||
+           name == "GlobalSdomId2Rank";
+#else
+    (void)name;
+    return false;
+#endif
+  }
+
+  RAJA_INLINE
+  chai::ExecutionSpace fieldAllocationSpace(std::string const &name, ArchV arch_v)
   {
 #ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
     (void)arch_v;
+    if(singleMemoryGpuAwareMpiMode()){
+      return chai::GPU;
+    }
+    if(hostResidentSingleMemoryField(name)){
+      return chai::CPU;
+    }
     return chai::GPU;
 #else
 #if defined(KRIPKE_USE_CUDA)
@@ -168,7 +203,7 @@ namespace Kripke {
       using order_t = typename DefaultOrder<decltype(layout_t)>::type; 
 
 #ifdef KRIPKE_USE_CHAI
-      field = new FieldType(set, fieldAllocationSpace(al_v.arch_v), order_t{});
+      field = new FieldType(set, fieldAllocationSpace(name, al_v.arch_v), order_t{});
 #else
       field = new FieldType(set, order_t{});
 #endif

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -167,9 +167,6 @@ namespace Kripke {
   {
 #ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
     (void)arch_v;
-    if(singleMemoryGpuAwareMpiMode()){
-      return chai::GPU;
-    }
     if(FieldType::host_resident_single_memory){
       return chai::CPU;
     }

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -44,9 +44,24 @@ namespace Kripke {
   using Field_SigmaS = Kripke::Core::Field<double, Material, Legendre, GlobalGroup, GlobalGroup>;
 
   using Field_Direction2Double = Kripke::Core::Field<double, Direction>;
-  using Field_Direction2Int    = Kripke::Core::Field<int, Direction>;
 
-  using Field_Adjacency        = Kripke::Core::Field<GlobalSdomId, Dimension>;
+  struct FieldTag_QuadratureDirectionSign {};
+  struct FieldTag_QuadratureOctant {};
+  struct FieldTag_Adjacency {};
+
+  using Field_QuadratureDirectionSign =
+      Kripke::Core::Field<int,
+                          Kripke::Core::FieldPolicy<FieldTag_QuadratureDirectionSign, true>,
+                          Direction>;
+  using Field_QuadratureOctant =
+      Kripke::Core::Field<int,
+                          Kripke::Core::FieldPolicy<FieldTag_QuadratureOctant, true>,
+                          Direction>;
+
+  using Field_Adjacency =
+      Kripke::Core::Field<GlobalSdomId,
+                          Kripke::Core::FieldPolicy<FieldTag_Adjacency, true>,
+                          Dimension>;
 
   using Field_Moment2Legendre  = Kripke::Core::Field<Legendre, Moment>;
 
@@ -146,34 +161,16 @@ namespace Kripke {
 #endif
   }
 
+  template<typename FieldType>
   RAJA_INLINE
-  bool hostResidentSingleMemoryField(std::string const &name)
-  {
-#ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
-    return name == "quadrature/id" ||
-           name == "quadrature/jd" ||
-           name == "quadrature/kd" ||
-           name == "quadrature/octant" ||
-           name == "upwind" ||
-           name == "downwind" ||
-           name == "SdomId2GlobalSdomId" ||
-           name == "GlobalSdomId2SdomId" ||
-           name == "GlobalSdomId2Rank";
-#else
-    (void)name;
-    return false;
-#endif
-  }
-
-  RAJA_INLINE
-  chai::ExecutionSpace fieldAllocationSpace(std::string const &name, ArchV arch_v)
+  chai::ExecutionSpace fieldAllocationSpace(ArchV arch_v)
   {
 #ifdef KRIPKE_USE_CHAI_SINGLE_MEMORY
     (void)arch_v;
     if(singleMemoryGpuAwareMpiMode()){
       return chai::GPU;
     }
-    if(hostResidentSingleMemoryField(name)){
+    if(FieldType::host_resident_single_memory){
       return chai::CPU;
     }
     return chai::GPU;
@@ -203,7 +200,7 @@ namespace Kripke {
       using order_t = typename DefaultOrder<decltype(layout_t)>::type; 
 
 #ifdef KRIPKE_USE_CHAI
-      field = new FieldType(set, fieldAllocationSpace(name, al_v.arch_v), order_t{});
+      field = new FieldType(set, fieldAllocationSpace<FieldType>(al_v.arch_v), order_t{});
 #else
       field = new FieldType(set, order_t{});
 #endif

--- a/src/KripkeConfig.h.in
+++ b/src/KripkeConfig.h.in
@@ -12,6 +12,7 @@
 #cmakedefine KRIPKE_USE_CUDA
 #cmakedefine KRIPKE_USE_CHAI
 #cmakedefine KRIPKE_USE_CHAI_SINGLE_MEMORY
+#cmakedefine KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI
 #cmakedefine KRIPKE_USE_HIP
 
 #cmakedefine KRIPKE_USE_CALIPER

--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <sstream>
 
@@ -188,6 +189,17 @@ int main(int argc, char **argv) {
 
   int myid = comm.rank();
   int num_tasks = comm.size();
+
+#if defined(KRIPKE_USE_MPI) && defined(KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI)
+  char const *gpu_mpi = std::getenv("MPICH_GPU_SUPPORT_ENABLED");
+  if(gpu_mpi == nullptr || strcmp(gpu_mpi, "1") != 0){
+    if(myid == 0){
+      printf("KRIPKE_USE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI requires "
+             "MPICH_GPU_SUPPORT_ENABLED=1\n");
+    }
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+#endif
 
   if (myid == 0) {
     /* Print out a banner message along with a version number. */


### PR DESCRIPTION
In the CHAI single memory space model, this adds:

- Staged MPI, where most array allocations take place on the GPU, and a small number of plane communication arrays are allocated on the CPU. When MPI occurs, data is moved from the GPU to CPU buffers, and sent to ranks. Buffer overhead is roughly correlated to angles * groups * (xy plane size + yz plane size + xz plane size), on a per rank basis, which amounts to ~5% overhead. Overhead will vary on problem size. **This mode is intended to work on any system without the need to set environment variables (e.g. no need to set HSA_XNACK, nor MPICH_GPU_SUPPORT_ENABLED)**. Set the following to activate this path:
```
ENABLE_CHAI=On
ENABLE_CHAI_SINGLE_MEMORY=On
ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI=Off
```

- GPU-aware MPI is allowed with a single memory space CHAI model, in which case all memory is allocated on the GPU. This option requires the environment variable `MPICH_GPU_SUPPORT_ENABLED=1` to be set. Set the following to activate this path:
```
ENABLE_CHAI=On
ENABLE_CHAI_SINGLE_MEMORY=On
ENABLE_CHAI_SINGLE_MEMORY_GPU_AWARE_MPI=On
```