### PR TITLE
Kripke stand-alone umpire build

### DIFF
--- a/cmake/kripke/CMakeLists.txt
+++ b/cmake/kripke/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ENABLE_DOCUMENTATION Off CACHE BOOL "")
 
 if (ENABLE_CHAI)
   set(ENABLE_RAJA_PLUGIN On CACHE BOOL "")
+  set(CHAI_ENABLE_RAJA_PLUGIN On CACHE BOOL "")
 endif ()
 
 # Use C++17 standard
@@ -153,7 +154,7 @@ if(ENABLE_CHAI)
     find_package(umpire REQUIRED)
     
     if (ENABLE_MPI)
-      list(APPEND UMPIRE_DEPENDS blt::mpi)
+      set(UMPIRE_DEPENDS "${UMPIRE_DEPENDS} blt::mpi")
     endif()
 
     blt_register_library(
@@ -166,23 +167,97 @@ if(ENABLE_CHAI)
                      ${PROJECT_BINARY_DIR}/umpire)
   endif()
 
+  if (DEFINED chai_DIR)
+    find_package(chai REQUIRED)
+  else ()
+    add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/chai
+                     ${PROJECT_BINARY_DIR}/chai)
+  endif ()
+
   set(ENABLE_TESTS Off CACHE BOOL "")
   set(KRIPKE_USE_CHAI 1)
-  list(APPEND KRIPKE_DEPENDS umpire)
+  set(KRIPKE_USE_UMPIRE 1)
+  list(APPEND KRIPKE_DEPENDS chai)
 else ()
-  #
-  # Configure RAJA (REQUIRED)
-  #
-  set(ENABLE_RAJA_PLUGIN Off CACHE BOOL "")
-  if (DEFINED RAJA_DIR)
-    find_package(RAJA REQUIRED)
+  if (ENABLE_CUDA OR ENABLE_HIP) 
+    set(ENABLE_RAJA_PLUGIN Off CACHE BOOL "")
+    # Find camp
+    if (NOT TARGET camp)
+      find_package(camp QUIET NO_DEFAULT_PATH HINTS ${CAMP_DIR} ${camp_DIR})
+
+      if (camp_FOUND)
+        message(STATUS "Kripke: Using external CAMP")
+        set_target_properties(camp PROPERTIES IMPORTED_GLOBAL TRUE)
+        if (DEFINED RAJA_DIR)
+          find_package(RAJA REQUIRED)
+        endif()
+
+        list(APPEND KRIPKE_DEPENDS RAJA)
+      else ()
+        message(STATUS "Kripke: Using CAMP submodule")
+
+        if (NOT EXISTS ${KRIPKE_SOURCE_DIR}/tpl/raja/tpl/camp/CMakeLists.txt)
+          message(FATAL_ERROR "Kripke: CAMP submodule not initialized. Run 'git submodule update --init' in the git repository or set camp_DIR or CAMP_DIR to use an external build of CAMP.")
+        else ()
+          message(STATUS "Kripke: Using CAMP in Kripke TPL")
+          add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/raja/tpl/camp
+                           ${PROJECT_BINARY_DIR}/camp)
+        endif ()
+      endif()
+    endif()
+
+    # Set camp backends
+    if (ENABLE_CUDA)
+      message(STATUS "Kripke: Setting CAMP_HAVE_CUDA")
+      blt_add_target_definitions(TO camp
+                                 SCOPE INTERFACE
+                                 TARGET_DEFINITIONS CAMP_HAVE_CUDA)
+    endif ()
+
+    if (ENABLE_HIP)
+      message(STATUS "Kripke: Setting CAMP_HAVE_HIP")
+      blt_add_target_definitions(TO camp
+                                 SCOPE INTERFACE
+                                 TARGET_DEFINITIONS CAMP_HAVE_HIP)
+    endif ()
+
+    set(UMPIRE_DEPENDS camp)
+
+    if (DEFINED umpire_DIR)
+      find_package(umpire REQUIRED)
+      
+      if (ENABLE_MPI)
+        list(APPEND UMPIRE_DEPENDS blt::mpi)
+      endif()
+
+      blt_register_library(
+        NAME umpire
+        INCLUDES ${UMPIRE_INCLUDE_DIRS}
+        LIBRARIES umpire
+        DEPENDS_ON ${UMPIRE_DEPENDS})
+    else ()
+      add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/umpire
+                       ${PROJECT_BINARY_DIR}/umpire)
+    endif()
+
+    set(ENABLE_TESTS Off CACHE BOOL "")
+    set(KRIPKE_USE_UMPIRE 1)
+    list(APPEND KRIPKE_DEPENDS umpire)
   else ()
-    set(ENABLE_EXAMPLES Off CACHE BOOL "")
-    set(ENABLE_EXERCISES Off CACHE BOOL "")
-    add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/raja
-                     ${PROJECT_BINARY_DIR}/raja)
+    #
+    # Configure RAJA (REQUIRED)
+    #
+    set(ENABLE_RAJA_PLUGIN Off CACHE BOOL "")
+    if (DEFINED RAJA_DIR)
+      find_package(RAJA REQUIRED)
+    else ()
+      set(ENABLE_EXAMPLES Off CACHE BOOL "")
+      set(ENABLE_EXERCISES Off CACHE BOOL "")
+      add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/raja
+                       ${PROJECT_BINARY_DIR}/raja)
+    endif ()
+    list(APPEND KRIPKE_DEPENDS RAJA)
   endif ()
-  list(APPEND KRIPKE_DEPENDS RAJA)
 endif ()
 
 #

--- a/cmake/kripke/CMakeLists.txt
+++ b/cmake/kripke/CMakeLists.txt
@@ -153,7 +153,7 @@ if(ENABLE_CHAI)
     find_package(umpire REQUIRED)
     
     if (ENABLE_MPI)
-      set(UMPIRE_DEPENDS "${UMPIRE_DEPENDS} blt::mpi")
+      list(APPEND UMPIRE_DEPENDS blt::mpi)
     endif()
 
     blt_register_library(

--- a/cmake/kripke/CMakeLists.txt
+++ b/cmake/kripke/CMakeLists.txt
@@ -30,7 +30,6 @@ set(ENABLE_DOCUMENTATION Off CACHE BOOL "")
 
 if (ENABLE_CHAI)
   set(ENABLE_RAJA_PLUGIN On CACHE BOOL "")
-  set(CHAI_ENABLE_RAJA_PLUGIN On CACHE BOOL "")
 endif ()
 
 # Use C++17 standard
@@ -167,16 +166,9 @@ if(ENABLE_CHAI)
                      ${PROJECT_BINARY_DIR}/umpire)
   endif()
 
-  if (DEFINED chai_DIR)
-    find_package(chai REQUIRED)
-  else ()
-    add_subdirectory(${KRIPKE_SOURCE_DIR}/tpl/chai
-                     ${PROJECT_BINARY_DIR}/chai)
-  endif ()
-
   set(ENABLE_TESTS Off CACHE BOOL "")
   set(KRIPKE_USE_CHAI 1)
-  list(APPEND KRIPKE_DEPENDS chai)
+  list(APPEND KRIPKE_DEPENDS umpire)
 else ()
   #
   # Configure RAJA (REQUIRED)

--- a/src/Kripke.h
+++ b/src/Kripke.h
@@ -31,11 +31,11 @@
 #include <mpi.h>
 #endif
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
 #define DEBUG
 #include <umpire/Umpire.hpp>
 #include <umpire/strategy/QuickPool.hpp>
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
 #include <chai/ManagedArray.hpp>
 #endif
 #undef DEBUG
@@ -78,8 +78,8 @@ namespace Kripke {
    */
   RAJA_INDEX_VALUE(GlobalSdomId, "GlobalSdomId");
 
-#ifdef KRIPKE_USE_UMPIRE
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_UMPIRE)
+#if defined(KRIPKE_USE_CHAI)
   using ExecutionSpace = chai::ExecutionSpace;
   using chai::CPU;
   using chai::GPU;

--- a/src/Kripke.h
+++ b/src/Kripke.h
@@ -68,6 +68,13 @@ namespace Kripke {
    */
   RAJA_INDEX_VALUE(GlobalSdomId, "GlobalSdomId");
 
+#ifdef KRIPKE_USE_CHAI
+  enum ExecutionSpace {
+    CPU,
+    GPU
+  };
+#endif
+
 
 }
 
@@ -160,4 +167,3 @@ namespace Arch {
 
 
 #endif
-

--- a/src/Kripke.h
+++ b/src/Kripke.h
@@ -31,6 +31,16 @@
 #include <mpi.h>
 #endif
 
+#ifdef KRIPKE_USE_UMPIRE
+#define DEBUG
+#include <umpire/Umpire.hpp>
+#include <umpire/strategy/QuickPool.hpp>
+#ifdef KRIPKE_USE_CHAI
+#include <chai/ManagedArray.hpp>
+#endif
+#undef DEBUG
+#endif
+
 // Forward Decl
 struct Grid_Data;
 
@@ -68,11 +78,17 @@ namespace Kripke {
    */
   RAJA_INDEX_VALUE(GlobalSdomId, "GlobalSdomId");
 
+#ifdef KRIPKE_USE_UMPIRE
 #ifdef KRIPKE_USE_CHAI
+  using ExecutionSpace = chai::ExecutionSpace;
+  using chai::CPU;
+  using chai::GPU;
+#else
   enum ExecutionSpace {
     CPU,
     GPU
   };
+#endif
 #endif
 
 

--- a/src/Kripke/Core/DataStore.cpp
+++ b/src/Kripke/Core/DataStore.cpp
@@ -8,6 +8,14 @@
 #include <Kripke.h>
 #include <Kripke/Core/DataStore.h>
 
+#ifdef KRIPKE_USE_CHAI
+#define DEBUG
+#include <umpire/Umpire.hpp>
+#include <umpire/strategy/QuickPool.hpp>
+#include <chai/ManagedArray.hpp>
+#undef DEBUG
+#endif
+
 using namespace Kripke;
 using namespace Kripke::Core;
 

--- a/src/Kripke/Core/DataStore.cpp
+++ b/src/Kripke/Core/DataStore.cpp
@@ -8,14 +8,6 @@
 #include <Kripke.h>
 #include <Kripke/Core/DataStore.h>
 
-#ifdef KRIPKE_USE_CHAI
-#define DEBUG
-#include <umpire/Umpire.hpp>
-#include <umpire/strategy/QuickPool.hpp>
-#include <chai/ManagedArray.hpp>
-#undef DEBUG
-#endif
-
 using namespace Kripke;
 using namespace Kripke::Core;
 

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -12,11 +12,15 @@
 #include <Kripke/Core/VarLayout.h>
 #include <Kripke/Core/DataStore.h>
 #include <Kripke/Core/DomainVar.h>
+#include <Kripke/Core/MemoryManager.h>
 #include <Kripke/Core/Set.h>
+#include <cstring>
 #include <vector>
 
 #ifdef KRIPKE_USE_CHAI
-#include <chai/ManagedArray.hpp>
+#define DEBUG
+#include <umpire/Umpire.hpp>
+#undef DEBUG
 #endif
 
 namespace Kripke {
@@ -31,12 +35,7 @@ namespace Core {
   class FieldStorage : public Kripke::Core::DomainVar {
     public:
       using ElementType = ELEMENT;
-
-#ifndef KRIPKE_USE_CHAI
       using ElementPtr = ELEMENT*;
-#else
-      using ElementPtr = chai::ManagedArray<ELEMENT>;
-#endif
 
       using Layout1dType = RAJA::TypedLayout<RAJA::Index_type, camp::tuple<RAJA::Index_type>>;
       //FIXME: Remove the internal namespace when new RAJA release is out
@@ -45,7 +44,7 @@ namespace Core {
 
       explicit FieldStorage(Kripke::Core::Set const &spanned_set
 #ifdef KRIPKE_USE_CHAI
-          , chai::ExecutionSpace allocation_space = chai::CPU
+          , Kripke::ExecutionSpace allocation_space = Kripke::CPU
 #endif
           ) :
         m_set(&spanned_set)
@@ -71,34 +70,21 @@ namespace Core {
           // Get the size of the subdomain from the set
           SdomId sdom_id(m_chunk_to_subdomain[chunk_id]);
           size_t sdom_size = spanned_set.size(sdom_id);
+          size_t bytes = sdom_size*sizeof(ElementType);
 
           m_chunk_to_size[chunk_id] = sdom_size;
 #ifndef KRIPKE_USE_CHAI
           m_chunk_to_data[chunk_id] = new ElementType[sdom_size];
 #else
-          m_chunk_to_data[chunk_id].allocate(sdom_size, m_allocation_space,
-              [=](const chai::PointerRecord* record, chai::Action action, chai::ExecutionSpace space){
-                /*printf("CHAI[%s, %d]: ", BaseVar::getName().c_str(), (int)chunk_id);
-                switch(action){
-                case chai::ACTION_ALLOC: printf("ALLOC "); break;
-                case chai::ACTION_FREE: printf("FREE  "); break;
-                case chai::ACTION_MOVE: printf("MOVE  "); break;
-                default: printf("UNKNOWN ");
-                }
-
-                switch(space){
-                case chai::CPU: printf("CPU "); break;
-#ifdef KRIPKE_USE_CUDA
-                case chai::GPU: printf("GPU  "); break;
-#endif
-                default: printf("UNK ");
-                }
-
-                printf("%lu bytes\n", (unsigned long) bytes);
-*/
-              }
-
-          );
+          auto &chunk = m_chunk_to_data[chunk_id];
+          if(m_allocation_space == Kripke::GPU){
+            chunk.device_ptr = allocateDeviceBuffer(bytes);
+            chunk.last_space = Kripke::GPU;
+          }
+          else{
+            chunk.host_ptr = allocateHostBuffer(bytes);
+            chunk.last_space = Kripke::CPU;
+          }
 #endif
         }
       }
@@ -107,6 +93,16 @@ namespace Core {
 #ifndef KRIPKE_USE_CHAI
         for(auto i : m_chunk_to_data){
           delete[] i;
+        }
+#else
+        auto host_allocator = MemoryManager::getHostAllocator();
+        for(auto &chunk : m_chunk_to_data){
+          if(chunk.device_ptr != nullptr){
+            MemoryManager::getDeviceAllocator().deallocate(chunk.device_ptr);
+          }
+          if(chunk.host_ptr != nullptr){
+            host_allocator.deallocate(chunk.host_ptr);
+          }
         }
 #endif
       }
@@ -126,13 +122,8 @@ namespace Core {
 
       RAJA_INLINE
       View1dType getView1d(Kripke::SdomId sdom_id) const {
-
+        ElementPtr ptr = getHostData(sdom_id);
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
-
-#ifdef KRIPKE_USE_CHAI
-        m_chunk_to_data[chunk_id].data(chai::CPU);
-#endif
-        ElementPtr ptr = m_chunk_to_data[chunk_id];
         size_t sdom_size = m_chunk_to_size[chunk_id];
 
         return View1dType(ptr, Layout1dType(sdom_size));
@@ -149,7 +140,9 @@ namespace Core {
 #ifndef KRIPKE_USE_CHAI
         return  m_chunk_to_data[chunk_id];
 #else
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
+        ensureHostCurrent(chunk_id);
+        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
+        return m_chunk_to_data[chunk_id].host_ptr;
 #endif
       }
 
@@ -164,7 +157,8 @@ namespace Core {
 #ifndef KRIPKE_USE_CHAI
         return  m_chunk_to_data[chunk_id];
 #else
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
+        ensureHostCurrent(chunk_id);
+        return m_chunk_to_data[chunk_id].host_ptr;
 #endif
       }
 
@@ -180,9 +174,17 @@ namespace Core {
         return  m_chunk_to_data[chunk_id];
 #else
 #if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
-        return m_chunk_to_data[chunk_id].data(chai::GPU);
+        if(m_allocation_space == Kripke::GPU){
+          ensureDeviceCurrent(chunk_id);
+          m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
+          return m_chunk_to_data[chunk_id].device_ptr;
+        }
+        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
+        return m_chunk_to_data[chunk_id].host_ptr;
 #else
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
+        ensureHostCurrent(chunk_id);
+        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
+        return m_chunk_to_data[chunk_id].host_ptr;
 #endif
 #endif
       }
@@ -194,20 +196,20 @@ namespace Core {
 
 #ifdef KRIPKE_USE_CHAI
       RAJA_INLINE
-      chai::ExecutionSpace getAllocationSpace() const {
+      Kripke::ExecutionSpace getAllocationSpace() const {
         return m_allocation_space;
       }
 
       RAJA_INLINE
       void registerDeviceTouch(Kripke::SdomId sdom_id) {
 #if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
-        if(m_allocation_space == chai::GPU){
+        if(m_allocation_space == Kripke::GPU){
           KRIPKE_ASSERT(*sdom_id < (int)m_subdomain_to_chunk.size(),
               "sdom_id(%d) >= num_subdomains(%d)",
               (int)*sdom_id,
               (int)(int)m_subdomain_to_chunk.size());
           size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
-          m_chunk_to_data[chunk_id].registerTouch(chai::GPU);
+          m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
         }
 #else
         (void)sdom_id;
@@ -222,11 +224,82 @@ namespace Core {
       }
 
     protected:
+#ifdef KRIPKE_USE_CHAI
+      struct ChunkData {
+        ElementType *host_ptr = nullptr;
+        ElementType *device_ptr = nullptr;
+        mutable Kripke::ExecutionSpace last_space = Kripke::CPU;
+      };
+
+      RAJA_INLINE
+      static ElementType *allocateHostBuffer(size_t bytes) {
+        if(bytes == 0){
+          return nullptr;
+        }
+        return static_cast<ElementType*>(MemoryManager::getHostAllocator().allocate(bytes));
+      }
+
+      RAJA_INLINE
+      static ElementType *allocateDeviceBuffer(size_t bytes) {
+        if(bytes == 0){
+          return nullptr;
+        }
+        return static_cast<ElementType*>(MemoryManager::getDeviceAllocator().allocate(bytes));
+      }
+
+      RAJA_INLINE
+      void ensureHostCurrent(size_t chunk_id) const {
+        if(m_allocation_space != Kripke::GPU ||
+           m_chunk_to_data[chunk_id].device_ptr == nullptr ||
+           m_chunk_to_data[chunk_id].last_space == Kripke::CPU){
+          return;
+        }
+
+        if(m_chunk_to_data[chunk_id].host_ptr == nullptr){
+          m_chunk_to_data[chunk_id].host_ptr = allocateHostBuffer(
+              m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        }
+        synchronizeDevice();
+        MemoryManager::copy(m_chunk_to_data[chunk_id].host_ptr,
+                            m_chunk_to_data[chunk_id].device_ptr,
+                            m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
+      }
+
+      RAJA_INLINE
+      void ensureDeviceCurrent(size_t chunk_id) const {
+        if(m_allocation_space != Kripke::GPU ||
+           m_chunk_to_data[chunk_id].last_space == Kripke::GPU){
+          return;
+        }
+
+        if(m_chunk_to_data[chunk_id].device_ptr == nullptr){
+          m_chunk_to_data[chunk_id].device_ptr = allocateDeviceBuffer(
+              m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        }
+        MemoryManager::copy(m_chunk_to_data[chunk_id].device_ptr,
+                            m_chunk_to_data[chunk_id].host_ptr,
+                            m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
+      }
+
+      RAJA_INLINE
+      void synchronizeDevice() const {
+#if defined(KRIPKE_USE_CUDA)
+        RAJA::synchronize<RAJA::cuda_synchronize>();
+#elif defined(KRIPKE_USE_HIP)
+        RAJA::synchronize<RAJA::hip_synchronize>();
+#endif
+      }
+#endif
+
       Kripke::Core::Set const *m_set;
       std::vector<size_t> m_chunk_to_size;
+#ifndef KRIPKE_USE_CHAI
       std::vector<ElementPtr> m_chunk_to_data;
-#ifdef KRIPKE_USE_CHAI
-      chai::ExecutionSpace m_allocation_space;
+#else
+      mutable std::vector<ChunkData> m_chunk_to_data;
+      Kripke::ExecutionSpace m_allocation_space;
 #endif
 	  };
 
@@ -241,11 +314,7 @@ namespace Core {
 
       using ElementType = ELEMENT;
       static constexpr bool host_resident_normal_chai_gpu = false;
-#ifndef KRIPKE_USE_CHAI
       using ElementPtr = ELEMENT*;
-#else
-      using ElementPtr = chai::ManagedArray<ELEMENT>;
-#endif
 
       static constexpr size_t NumDims = sizeof...(IDX_TYPES);
 
@@ -265,7 +334,7 @@ namespace Core {
 #ifdef KRIPKE_USE_CHAI
       template<typename Order>
       Field(Kripke::Core::Set const &spanned_set,
-            chai::ExecutionSpace allocation_space,
+            Kripke::ExecutionSpace allocation_space,
             Order) :
         Parent(spanned_set, allocation_space)
       {
@@ -308,13 +377,8 @@ namespace Core {
 
       RAJA_INLINE
       DefaultViewType getView(Kripke::SdomId sdom_id) const {
-
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
-
-#ifdef KRIPKE_USE_CHAI
-        Parent::m_chunk_to_data[chunk_id].data(chai::CPU);
-#endif
-        auto ptr = Parent::m_chunk_to_data[chunk_id];
+        auto ptr = Parent::getHostData(sdom_id);
         auto layout = m_chunk_to_layout[chunk_id];
 
         return DefaultViewType(ptr, layout);
@@ -328,11 +392,11 @@ namespace Core {
         auto layout = m_chunk_to_layout[chunk_id];
 
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-        KRIPKE_ASSERT(Parent::m_allocation_space == chai::GPU,
+        KRIPKE_ASSERT(Parent::m_allocation_space == Kripke::GPU,
             "getDeviceView requires a GPU-backed field");
-        auto ptr = Parent::m_chunk_to_data[chunk_id].data(chai::GPU);
+        auto ptr = Parent::getDeviceData(sdom_id);
 #elif defined(KRIPKE_USE_CHAI)
-        auto ptr = Parent::m_chunk_to_data[chunk_id].data(chai::CPU);
+        auto ptr = Parent::getHostData(sdom_id);
 #else
         auto ptr = Parent::m_chunk_to_data[chunk_id];
 #endif
@@ -354,12 +418,12 @@ namespace Core {
         LType layout = RAJA::make_stride_one<LInfo::stride_one_dim>(m_chunk_to_layout[chunk_id]);
 
 #if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_CHAI)
-        if(Parent::m_allocation_space == chai::GPU){
-          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::GPU), layout);
+        if(Parent::m_allocation_space == Kripke::GPU){
+          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getDeviceData(sdom_id), layout);
         }
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
 #elif defined(KRIPKE_USE_CHAI)
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
 #else
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id], layout);
 #endif
@@ -380,6 +444,13 @@ namespace Core {
 #ifndef KRIPKE_USE_CHAI
         printf("  m_chunk_to_data: ");
         for(auto x : Parent::m_chunk_to_data){printf("%p ", x);}
+        printf("\n");
+#else
+        printf("  m_chunk_to_data(host): ");
+        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.host_ptr);}
+        printf("\n");
+        printf("  m_chunk_to_data(device): ");
+        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.device_ptr);}
         printf("\n");
 #endif
 

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -221,7 +221,7 @@ namespace Core {
       RAJA_INLINE
       void registerDeviceTouch(Kripke::SdomId sdom_id) {
 #if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
-        if(m_allocation_space == chai::GPU){
+        if(m_allocation_space == Kripke::GPU){
           KRIPKE_ASSERT(*sdom_id < (int)m_subdomain_to_chunk.size(),
               "sdom_id(%d) >= num_subdomains(%d)",
               (int)*sdom_id,
@@ -459,7 +459,7 @@ namespace Core {
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
 
 #if defined(KRIPKE_USE_CHAI)
-        Parent::m_chunk_to_data[chunk_id].data(chai::CPU);
+        Parent::m_chunk_to_data[chunk_id].data(Kripke::CPU);
         auto ptr = Parent::m_chunk_to_data[chunk_id];
 #elif defined(KRIPKE_USE_UMPIRE)
         Parent::ensureHostCurrent(chunk_id);
@@ -511,12 +511,12 @@ namespace Core {
         LType layout = RAJA::make_stride_one<LInfo::stride_one_dim>(m_chunk_to_layout[chunk_id]);
 
 #if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_CHAI)
-        if(Parent::m_allocation_space == chai::GPU){
-          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::GPU), layout);
+        if(Parent::m_allocation_space == Kripke::GPU){
+          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(Kripke::GPU), layout);
         }
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(Kripke::CPU), layout);
 #elif defined(KRIPKE_USE_CHAI)
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(Kripke::CPU), layout);
 #elif (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_UMPIRE)
         if(Parent::m_allocation_space == Kripke::GPU){
           Parent::ensureDeviceCurrent(chunk_id);

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -18,9 +18,7 @@
 #include <vector>
 
 #ifdef KRIPKE_USE_CHAI
-#define DEBUG
-#include <umpire/Umpire.hpp>
-#undef DEBUG
+#include <chai/ManagedArray.hpp>
 #endif
 
 namespace Kripke {
@@ -35,7 +33,12 @@ namespace Core {
   class FieldStorage : public Kripke::Core::DomainVar {
     public:
       using ElementType = ELEMENT;
+
+#ifndef KRIPKE_USE_CHAI
       using ElementPtr = ELEMENT*;
+#else
+      using ElementPtr = chai::ManagedArray<ELEMENT>;
+#endif
 
       using Layout1dType = RAJA::TypedLayout<RAJA::Index_type, camp::tuple<RAJA::Index_type>>;
       //FIXME: Remove the internal namespace when new RAJA release is out
@@ -43,12 +46,12 @@ namespace Core {
 
 
       explicit FieldStorage(Kripke::Core::Set const &spanned_set
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
           , Kripke::ExecutionSpace allocation_space = Kripke::CPU
 #endif
           ) :
         m_set(&spanned_set)
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
         , m_allocation_space(allocation_space)
 #endif
       {
@@ -70,40 +73,67 @@ namespace Core {
           // Get the size of the subdomain from the set
           SdomId sdom_id(m_chunk_to_subdomain[chunk_id]);
           size_t sdom_size = spanned_set.size(sdom_id);
-          size_t bytes = sdom_size*sizeof(ElementType);
 
           m_chunk_to_size[chunk_id] = sdom_size;
 #ifndef KRIPKE_USE_CHAI
+#ifndef KRIPKE_USE_UMPIRE // No memory manager
           m_chunk_to_data[chunk_id] = new ElementType[sdom_size];
-#else
+#else // Umpire
           auto &chunk = m_chunk_to_data[chunk_id];
           if(m_allocation_space == Kripke::GPU){
-            chunk.device_ptr = allocateDeviceBuffer(bytes);
+            chunk.device_ptr = allocateDeviceBuffer(sdom_size*sizeof(ElementType));
             chunk.last_space = Kripke::GPU;
           }
           else{
-            chunk.host_ptr = allocateHostBuffer(bytes);
+            chunk.host_ptr = allocateHostBuffer(sdom_size*sizeof(ElementType));
             chunk.last_space = Kripke::CPU;
           }
+#endif
+#else // CHAI
+          m_chunk_to_data[chunk_id].allocate(sdom_size, m_allocation_space,
+              [=](const chai::PointerRecord* record, chai::Action action, Kripke::ExecutionSpace space){
+                /*printf("CHAI[%s, %d]: ", BaseVar::getName().c_str(), (int)chunk_id);
+                switch(action){
+                case chai::ACTION_ALLOC: printf("ALLOC "); break;
+                case chai::ACTION_FREE: printf("FREE  "); break;
+                case chai::ACTION_MOVE: printf("MOVE  "); break;
+                default: printf("UNKNOWN ");
+                }
+
+                switch(space){
+                case chai::CPU: printf("CPU "); break;
+#ifdef KRIPKE_USE_CUDA
+                case chai::GPU: printf("GPU  "); break;
+#endif
+                default: printf("UNK ");
+                }
+
+                printf("%lu bytes\n", (unsigned long) bytes);
+*/
+              }
+
+          );
 #endif
         }
       }
 
       virtual ~FieldStorage(){
 #ifndef KRIPKE_USE_CHAI
+#ifndef KRIPKE_USE_UMPIRE // No memory manager
         for(auto i : m_chunk_to_data){
           delete[] i;
         }
-#else
-        auto host_allocator = MemoryManager::getHostAllocator();
+#else // Umpire
         for(auto &chunk : m_chunk_to_data){
           if(chunk.device_ptr != nullptr){
             MemoryManager::getDeviceAllocator().deallocate(chunk.device_ptr);
           }
           if(chunk.host_ptr != nullptr){
-            host_allocator.deallocate(chunk.host_ptr);
+            MemoryManager::getHostAllocator().deallocate(chunk.host_ptr);
           }
         }
+#endif
+// CHAI uses RAII semantics, hence no need to deallocate
 #endif
       }
 
@@ -122,8 +152,19 @@ namespace Core {
 
       RAJA_INLINE
       View1dType getView1d(Kripke::SdomId sdom_id) const {
-        ElementPtr ptr = getHostData(sdom_id);
+
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
+
+#ifdef KRIPKE_USE_UMPIRE
+#ifdef KRIPKE_USE_CHAI // CHAI
+        m_chunk_to_data[chunk_id].data(Kripke::CPU);
+        ElementPtr ptr = m_chunk_to_data[chunk_id];
+#else // Umpire
+        ElementPtr ptr = getHostData(sdom_id);
+#endif
+#else // No memory manager
+        ElementPtr ptr = m_chunk_to_data[chunk_id];
+#endif
         size_t sdom_size = m_chunk_to_size[chunk_id];
 
         return View1dType(ptr, Layout1dType(sdom_size));
@@ -138,11 +179,16 @@ namespace Core {
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
 #ifndef KRIPKE_USE_CHAI
-        return  m_chunk_to_data[chunk_id];
-#else
+#ifndef KRIPKE_USE_UMPIRE // No memory manager
+        return m_chunk_to_data[chunk_id];
+#else // Umpire
         ensureHostCurrent(chunk_id);
         m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
         return m_chunk_to_data[chunk_id].host_ptr;
+#endif
+#else // CHAI
+        return m_chunk_to_data[chunk_id].data(chai::CPU);
+#endif
 #endif
       }
 
@@ -155,10 +201,14 @@ namespace Core {
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
 #ifndef KRIPKE_USE_CHAI
+#ifndef KRIPKE_USE_UMPIRE // No memory manager
         return  m_chunk_to_data[chunk_id];
-#else
+#else // Umpire
         ensureHostCurrent(chunk_id);
         return m_chunk_to_data[chunk_id].host_ptr;
+#endif
+#else // CHAI
+        return m_chunk_to_data[chunk_id].data(chai::CPU);
 #endif
       }
 
@@ -171,9 +221,9 @@ namespace Core {
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
 #ifndef KRIPKE_USE_CHAI
+#ifndef KRIPKE_USE_UMPIRE // No memory manager
         return  m_chunk_to_data[chunk_id];
-#else
-#if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
+#else // Umpire
         if(m_allocation_space == Kripke::GPU){
           ensureDeviceCurrent(chunk_id);
           m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
@@ -181,10 +231,12 @@ namespace Core {
         }
         m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
         return m_chunk_to_data[chunk_id].host_ptr;
+#endif
+#else // CHAI
+#if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
+        return m_chunk_to_data[chunk_id].data(chai::GPU);
 #else
-        ensureHostCurrent(chunk_id);
-        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
-        return m_chunk_to_data[chunk_id].host_ptr;
+        return m_chunk_to_data[chunk_id].data(chai::CPU);
 #endif
 #endif
       }
@@ -194,7 +246,7 @@ namespace Core {
         return getHostData(sdom_id);
       }
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
       RAJA_INLINE
       Kripke::ExecutionSpace getAllocationSpace() const {
         return m_allocation_space;
@@ -209,7 +261,11 @@ namespace Core {
               (int)*sdom_id,
               (int)(int)m_subdomain_to_chunk.size());
           size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
+#ifdef KRIPKE_USE_CHAI
+          m_chunk_to_data[chunk_id].registerTouch(Kripke::GPU);
+#else
           m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
+#endif
         }
 #else
         (void)sdom_id;
@@ -224,7 +280,8 @@ namespace Core {
       }
 
     protected:
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
+#ifndef KRIPKE_USE_CHAI
       struct ChunkData {
         ElementType *host_ptr = nullptr;
         ElementType *device_ptr = nullptr;
@@ -292,14 +349,19 @@ namespace Core {
 #endif
       }
 #endif
+#endif
 
       Kripke::Core::Set const *m_set;
       std::vector<size_t> m_chunk_to_size;
-#ifndef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
+#ifdef KRIPKE_USE_CHAI
       std::vector<ElementPtr> m_chunk_to_data;
 #else
       mutable std::vector<ChunkData> m_chunk_to_data;
+#endif
       Kripke::ExecutionSpace m_allocation_space;
+#else
+      std::vector<ElementPtr> m_chunk_to_data;
 #endif
 	  };
 
@@ -314,7 +376,11 @@ namespace Core {
 
       using ElementType = ELEMENT;
       static constexpr bool host_resident_normal_chai_gpu = false;
+#ifndef KRIPKE_USE_CHAI
       using ElementPtr = ELEMENT*;
+#else
+      using ElementPtr = chai::ManagedArray<ELEMENT>;
+#endif
 
       static constexpr size_t NumDims = sizeof...(IDX_TYPES);
 
@@ -331,7 +397,7 @@ namespace Core {
         setupLayouts<Order>(spanned_set);
       }
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
       template<typename Order>
       Field(Kripke::Core::Set const &spanned_set,
             Kripke::ExecutionSpace allocation_space,
@@ -377,6 +443,7 @@ namespace Core {
 
       RAJA_INLINE
       DefaultViewType getView(Kripke::SdomId sdom_id) const {
+
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
         auto ptr = Parent::getHostData(sdom_id);
         auto layout = m_chunk_to_layout[chunk_id];
@@ -391,11 +458,11 @@ namespace Core {
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
         auto layout = m_chunk_to_layout[chunk_id];
 
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
         KRIPKE_ASSERT(Parent::m_allocation_space == Kripke::GPU,
             "getDeviceView requires a GPU-backed field");
         auto ptr = Parent::getDeviceData(sdom_id);
-#elif defined(KRIPKE_USE_CHAI)
+#elif defined(KRIPKE_USE_UMPIRE)
         auto ptr = Parent::getHostData(sdom_id);
 #else
         auto ptr = Parent::m_chunk_to_data[chunk_id];
@@ -417,12 +484,12 @@ namespace Core {
 
         LType layout = RAJA::make_stride_one<LInfo::stride_one_dim>(m_chunk_to_layout[chunk_id]);
 
-#if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_CHAI)
+#if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_UMPIRE)
         if(Parent::m_allocation_space == Kripke::GPU){
           return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getDeviceData(sdom_id), layout);
         }
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
-#elif defined(KRIPKE_USE_CHAI)
+#elif defined(KRIPKE_USE_UMPIRE)
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
 #else
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id], layout);

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -17,13 +17,9 @@
 #include <cstring>
 #include <vector>
 
-#ifdef KRIPKE_USE_CHAI
-#include <chai/ManagedArray.hpp>
-#endif
-
 namespace Kripke {
 namespace Core {
-  template<typename ELEMENT, bool HOST_RESIDENT_NORMAL_CHAI_GPU, typename ... IDX_TYPES>
+  template<typename ELEMENT, bool HOST_RESIDENT_NORMAL_GPU, typename ... IDX_TYPES>
   class FieldWithPolicy;
 
   /**
@@ -34,10 +30,10 @@ namespace Core {
     public:
       using ElementType = ELEMENT;
 
-#ifndef KRIPKE_USE_CHAI
-      using ElementPtr = ELEMENT*;
-#else
+#if defined(KRIPKE_USE_CHAI)
       using ElementPtr = chai::ManagedArray<ELEMENT>;
+#else
+      using ElementPtr = ELEMENT*;
 #endif
 
       using Layout1dType = RAJA::TypedLayout<RAJA::Index_type, camp::tuple<RAJA::Index_type>>;
@@ -46,12 +42,12 @@ namespace Core {
 
 
       explicit FieldStorage(Kripke::Core::Set const &spanned_set
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
           , Kripke::ExecutionSpace allocation_space = Kripke::CPU
 #endif
           ) :
         m_set(&spanned_set)
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
         , m_allocation_space(allocation_space)
 #endif
       {
@@ -62,10 +58,10 @@ namespace Core {
         // allocate all of our chunks, and create layouts for each one
         size_t num_chunks = m_chunk_to_subdomain.size();
         m_chunk_to_size.resize(num_chunks, 0);
-#ifndef KRIPKE_USE_CHAI
-        m_chunk_to_data.resize(num_chunks, nullptr);
-#else
+#if defined(KRIPKE_USE_CHAI) || defined(KRIPKE_USE_UMPIRE)
         m_chunk_to_data.resize(num_chunks);
+#else
+        m_chunk_to_data.resize(num_chunks, nullptr);
 #endif
 
         for(size_t chunk_id = 0;chunk_id < num_chunks;++ chunk_id){
@@ -75,21 +71,7 @@ namespace Core {
           size_t sdom_size = spanned_set.size(sdom_id);
 
           m_chunk_to_size[chunk_id] = sdom_size;
-#ifndef KRIPKE_USE_CHAI
-#ifndef KRIPKE_USE_UMPIRE // No memory manager
-          m_chunk_to_data[chunk_id] = new ElementType[sdom_size];
-#else // Umpire
-          auto &chunk = m_chunk_to_data[chunk_id];
-          if(m_allocation_space == Kripke::GPU){
-            chunk.device_ptr = allocateDeviceBuffer(sdom_size*sizeof(ElementType));
-            chunk.last_space = Kripke::GPU;
-          }
-          else{
-            chunk.host_ptr = allocateHostBuffer(sdom_size*sizeof(ElementType));
-            chunk.last_space = Kripke::CPU;
-          }
-#endif
-#else // CHAI
+#if defined(KRIPKE_USE_CHAI)
           m_chunk_to_data[chunk_id].allocate(sdom_size, m_allocation_space,
               [=](const chai::PointerRecord* record, chai::Action action, Kripke::ExecutionSpace space){
                 /*printf("CHAI[%s, %d]: ", BaseVar::getName().c_str(), (int)chunk_id);
@@ -113,17 +95,26 @@ namespace Core {
               }
 
           );
+#elif defined(KRIPKE_USE_UMPIRE)
+          auto &chunk = m_chunk_to_data[chunk_id];
+          if(m_allocation_space == Kripke::GPU){
+            chunk.device_ptr = allocateDeviceBuffer(sdom_size*sizeof(ElementType));
+            chunk.last_space = Kripke::GPU;
+          }
+          else{
+            chunk.host_ptr = allocateHostBuffer(sdom_size*sizeof(ElementType));
+            chunk.last_space = Kripke::CPU;
+          }
+#else
+          m_chunk_to_data[chunk_id] = new ElementType[sdom_size];
 #endif
         }
       }
 
       virtual ~FieldStorage(){
-#ifndef KRIPKE_USE_CHAI
-#ifndef KRIPKE_USE_UMPIRE // No memory manager
-        for(auto i : m_chunk_to_data){
-          delete[] i;
-        }
-#else // Umpire
+#if defined(KRIPKE_USE_CHAI)
+// CHAI uses RAII semantics, hence no need to deallocate
+#elif defined(KRIPKE_USE_UMPIRE)
         for(auto &chunk : m_chunk_to_data){
           if(chunk.device_ptr != nullptr){
             MemoryManager::getDeviceAllocator().deallocate(chunk.device_ptr);
@@ -132,8 +123,10 @@ namespace Core {
             MemoryManager::getHostAllocator().deallocate(chunk.host_ptr);
           }
         }
-#endif
-// CHAI uses RAII semantics, hence no need to deallocate
+#else
+        for(auto i : m_chunk_to_data){
+          delete[] i;
+        }
 #endif
       }
 
@@ -155,14 +148,12 @@ namespace Core {
 
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
-#ifdef KRIPKE_USE_UMPIRE
-#ifdef KRIPKE_USE_CHAI // CHAI
+#if defined(KRIPKE_USE_CHAI)
         m_chunk_to_data[chunk_id].data(Kripke::CPU);
         ElementPtr ptr = m_chunk_to_data[chunk_id];
-#else // Umpire
+#elif defined(KRIPKE_USE_UMPIRE)
         ElementPtr ptr = getHostData(sdom_id);
-#endif
-#else // No memory manager
+#else
         ElementPtr ptr = m_chunk_to_data[chunk_id];
 #endif
         size_t sdom_size = m_chunk_to_size[chunk_id];
@@ -178,17 +169,14 @@ namespace Core {
             (int)(int)m_subdomain_to_chunk.size());
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
-#ifndef KRIPKE_USE_CHAI
-#ifndef KRIPKE_USE_UMPIRE // No memory manager
-        return m_chunk_to_data[chunk_id];
-#else // Umpire
+#if defined(KRIPKE_USE_CHAI)
+        return m_chunk_to_data[chunk_id].data(Kripke::CPU);
+#elif defined(KRIPKE_USE_UMPIRE)
         ensureHostCurrent(chunk_id);
         m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
         return m_chunk_to_data[chunk_id].host_ptr;
-#endif
-#else // CHAI
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
-#endif
+#else
+        return m_chunk_to_data[chunk_id];
 #endif
       }
 
@@ -200,15 +188,13 @@ namespace Core {
             (int)(int)m_subdomain_to_chunk.size());
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
-#ifndef KRIPKE_USE_CHAI
-#ifndef KRIPKE_USE_UMPIRE // No memory manager
-        return  m_chunk_to_data[chunk_id];
-#else // Umpire
+#if defined(KRIPKE_USE_CHAI)
+        return m_chunk_to_data[chunk_id].data(Kripke::CPU);
+#elif defined(KRIPKE_USE_UMPIRE)
         ensureHostCurrent(chunk_id);
         return m_chunk_to_data[chunk_id].host_ptr;
-#endif
-#else // CHAI
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
+#else
+        return m_chunk_to_data[chunk_id];
 #endif
       }
 
@@ -220,10 +206,13 @@ namespace Core {
             (int)(int)m_subdomain_to_chunk.size());
         size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
 
-#ifndef KRIPKE_USE_CHAI
-#ifndef KRIPKE_USE_UMPIRE // No memory manager
-        return  m_chunk_to_data[chunk_id];
-#else // Umpire
+#if defined(KRIPKE_USE_CHAI)
+#if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
+        return m_chunk_to_data[chunk_id].data(Kripke::GPU);
+#else
+        return m_chunk_to_data[chunk_id].data(Kripke::CPU);
+#endif
+#elif defined(KRIPKE_USE_UMPIRE)
         if(m_allocation_space == Kripke::GPU){
           ensureDeviceCurrent(chunk_id);
           m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
@@ -231,13 +220,8 @@ namespace Core {
         }
         m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
         return m_chunk_to_data[chunk_id].host_ptr;
-#endif
-#else // CHAI
-#if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
-        return m_chunk_to_data[chunk_id].data(chai::GPU);
 #else
-        return m_chunk_to_data[chunk_id].data(chai::CPU);
-#endif
+        return m_chunk_to_data[chunk_id];
 #endif
       }
 
@@ -246,7 +230,7 @@ namespace Core {
         return getHostData(sdom_id);
       }
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
       RAJA_INLINE
       Kripke::ExecutionSpace getAllocationSpace() const {
         return m_allocation_space;
@@ -261,7 +245,7 @@ namespace Core {
               (int)*sdom_id,
               (int)(int)m_subdomain_to_chunk.size());
           size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
           m_chunk_to_data[chunk_id].registerTouch(Kripke::GPU);
 #else
           m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
@@ -280,8 +264,8 @@ namespace Core {
       }
 
     protected:
-#ifdef KRIPKE_USE_UMPIRE
-#ifndef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_UMPIRE)
+#if !defined(KRIPKE_USE_CHAI)
       struct ChunkData {
         ElementType *host_ptr = nullptr;
         ElementType *device_ptr = nullptr;
@@ -353,12 +337,10 @@ namespace Core {
 
       Kripke::Core::Set const *m_set;
       std::vector<size_t> m_chunk_to_size;
-#ifdef KRIPKE_USE_UMPIRE
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
       std::vector<ElementPtr> m_chunk_to_data;
-#else
+#elif defined(KRIPKE_USE_UMPIRE)
       mutable std::vector<ChunkData> m_chunk_to_data;
-#endif
       Kripke::ExecutionSpace m_allocation_space;
 #else
       std::vector<ElementPtr> m_chunk_to_data;
@@ -375,12 +357,8 @@ namespace Core {
       using Parent = Kripke::Core::FieldStorage<ELEMENT>;
 
       using ElementType = ELEMENT;
-      static constexpr bool host_resident_normal_chai_gpu = false;
-#ifndef KRIPKE_USE_CHAI
-      using ElementPtr = ELEMENT*;
-#else
-      using ElementPtr = chai::ManagedArray<ELEMENT>;
-#endif
+      static constexpr bool host_resident_normal_gpu = false;
+      using ElementPtr = typename Parent::ElementPtr;
 
       static constexpr size_t NumDims = sizeof...(IDX_TYPES);
 
@@ -397,7 +375,7 @@ namespace Core {
         setupLayouts<Order>(spanned_set);
       }
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
       template<typename Order>
       Field(Kripke::Core::Set const &spanned_set,
             Kripke::ExecutionSpace allocation_space,
@@ -508,16 +486,16 @@ namespace Core {
         for(auto x : Parent::m_chunk_to_size){printf("%lu ", (unsigned long)x);}
         printf("\n");
 
-#ifndef KRIPKE_USE_CHAI
-        printf("  m_chunk_to_data: ");
-        for(auto x : Parent::m_chunk_to_data){printf("%p ", x);}
-        printf("\n");
-#else
+#if defined(KRIPKE_USE_UMPIRE) && !defined(KRIPKE_USE_CHAI)
         printf("  m_chunk_to_data(host): ");
         for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.host_ptr);}
         printf("\n");
         printf("  m_chunk_to_data(device): ");
         for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.device_ptr);}
+        printf("\n");
+#else
+        printf("  m_chunk_to_data: ");
+        for(auto x : Parent::m_chunk_to_data){printf("%p ", (void*)x);}
         printf("\n");
 #endif
 
@@ -541,13 +519,13 @@ namespace Core {
       std::vector<DefaultLayoutType> m_chunk_to_layout;
   };
 
-  template<typename ELEMENT, bool HOST_RESIDENT_NORMAL_CHAI_GPU, typename ... IDX_TYPES>
+  template<typename ELEMENT, bool HOST_RESIDENT_NORMAL_GPU, typename ... IDX_TYPES>
   class FieldWithPolicy : public Kripke::Core::Field<ELEMENT, IDX_TYPES...> {
     public:
       using Parent = Kripke::Core::Field<ELEMENT, IDX_TYPES...>;
       using Parent::Parent;
-      static constexpr bool host_resident_normal_chai_gpu =
-          HOST_RESIDENT_NORMAL_CHAI_GPU;
+      static constexpr bool host_resident_normal_gpu =
+          HOST_RESIDENT_NORMAL_GPU;
   };
 
 } } // namespace

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -96,15 +96,7 @@ namespace Core {
 
           );
 #elif defined(KRIPKE_USE_UMPIRE)
-          auto &chunk = m_chunk_to_data[chunk_id];
-          if(m_allocation_space == Kripke::GPU){
-            chunk.device_ptr = allocateDeviceBuffer(sdom_size*sizeof(ElementType));
-            chunk.last_space = Kripke::GPU;
-          }
-          else{
-            chunk.host_ptr = allocateHostBuffer(sdom_size*sizeof(ElementType));
-            chunk.last_space = Kripke::CPU;
-          }
+          m_chunk_to_data[chunk_id].allocate(sdom_size, m_allocation_space);
 #else
           m_chunk_to_data[chunk_id] = new ElementType[sdom_size];
 #endif
@@ -116,12 +108,7 @@ namespace Core {
 // CHAI uses RAII semantics, hence no need to deallocate
 #elif defined(KRIPKE_USE_UMPIRE)
         for(auto &chunk : m_chunk_to_data){
-          if(chunk.device_ptr != nullptr){
-            MemoryManager::getDeviceAllocator().deallocate(chunk.device_ptr);
-          }
-          if(chunk.host_ptr != nullptr){
-            MemoryManager::getHostAllocator().deallocate(chunk.host_ptr);
-          }
+          chunk.deallocate();
         }
 #else
         for(auto i : m_chunk_to_data){
@@ -152,7 +139,8 @@ namespace Core {
         m_chunk_to_data[chunk_id].data(Kripke::CPU);
         ElementPtr ptr = m_chunk_to_data[chunk_id];
 #elif defined(KRIPKE_USE_UMPIRE)
-        ElementPtr ptr = getHostData(sdom_id);
+        ensureHostCurrent(chunk_id);
+        ElementPtr ptr = m_chunk_to_data[chunk_id].getHostPtr();
 #else
         ElementPtr ptr = m_chunk_to_data[chunk_id];
 #endif
@@ -173,8 +161,7 @@ namespace Core {
         return m_chunk_to_data[chunk_id].data(Kripke::CPU);
 #elif defined(KRIPKE_USE_UMPIRE)
         ensureHostCurrent(chunk_id);
-        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
-        return m_chunk_to_data[chunk_id].host_ptr;
+        return m_chunk_to_data[chunk_id].getHostPtr();
 #else
         return m_chunk_to_data[chunk_id];
 #endif
@@ -192,7 +179,7 @@ namespace Core {
         return m_chunk_to_data[chunk_id].data(Kripke::CPU);
 #elif defined(KRIPKE_USE_UMPIRE)
         ensureHostCurrent(chunk_id);
-        return m_chunk_to_data[chunk_id].host_ptr;
+        return m_chunk_to_data[chunk_id].getHostPtr();
 #else
         return m_chunk_to_data[chunk_id];
 #endif
@@ -212,14 +199,9 @@ namespace Core {
 #else
         return m_chunk_to_data[chunk_id].data(Kripke::CPU);
 #endif
-#elif defined(KRIPKE_USE_UMPIRE)
-        if(m_allocation_space == Kripke::GPU){
-          ensureDeviceCurrent(chunk_id);
-          m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
-          return m_chunk_to_data[chunk_id].device_ptr;
-        }
-        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
-        return m_chunk_to_data[chunk_id].host_ptr;
+#elif defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+        ensureDeviceCurrent(chunk_id);
+        return m_chunk_to_data[chunk_id].getDevicePtr();
 #else
         return m_chunk_to_data[chunk_id];
 #endif
@@ -239,17 +221,13 @@ namespace Core {
       RAJA_INLINE
       void registerDeviceTouch(Kripke::SdomId sdom_id) {
 #if defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP)
-        if(m_allocation_space == Kripke::GPU){
+        if(m_allocation_space == chai::GPU){
           KRIPKE_ASSERT(*sdom_id < (int)m_subdomain_to_chunk.size(),
               "sdom_id(%d) >= num_subdomains(%d)",
               (int)*sdom_id,
               (int)(int)m_subdomain_to_chunk.size());
           size_t chunk_id = m_subdomain_to_chunk[*sdom_id];
-#if defined(KRIPKE_USE_CHAI)
           m_chunk_to_data[chunk_id].registerTouch(Kripke::GPU);
-#else
-          m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
-#endif
         }
 #else
         (void)sdom_id;
@@ -266,10 +244,67 @@ namespace Core {
     protected:
 #if defined(KRIPKE_USE_UMPIRE)
 #if !defined(KRIPKE_USE_CHAI)
-      struct ChunkData {
-        ElementType *host_ptr = nullptr;
-        ElementType *device_ptr = nullptr;
-        mutable Kripke::ExecutionSpace last_space = Kripke::CPU;
+      class ChunkData {
+        public:
+          RAJA_INLINE
+          void allocate(size_t num_elements, Kripke::ExecutionSpace allocation_space) {
+            size_t bytes = num_elements*sizeof(ElementType);
+            if(allocation_space == Kripke::GPU){
+              m_device_ptr = FieldStorage::allocateDeviceBuffer(bytes);
+              m_last_space = Kripke::GPU;
+            }
+            else{
+              m_host_ptr = FieldStorage::allocateHostBuffer(bytes);
+              m_last_space = Kripke::CPU;
+            }
+          }
+
+          RAJA_INLINE
+          void registerTouch(Kripke::ExecutionSpace space) const {
+            m_last_space = space;
+          }
+
+          RAJA_INLINE
+          void deallocate() {
+            if(m_device_ptr != nullptr){
+              MemoryManager::getDeviceAllocator().deallocate(m_device_ptr);
+              m_device_ptr = nullptr;
+            }
+            if(m_host_ptr != nullptr){
+              MemoryManager::getHostAllocator().deallocate(m_host_ptr);
+              m_host_ptr = nullptr;
+            }
+          }
+
+          RAJA_INLINE
+          ElementType *getHostPtr() const {
+            return m_host_ptr;
+          }
+
+          RAJA_INLINE
+          void setHostPtr(ElementType *ptr) {
+            m_host_ptr = ptr;
+          }
+
+          RAJA_INLINE
+          ElementType *getDevicePtr() const {
+            return m_device_ptr;
+          }
+
+          RAJA_INLINE
+          void setDevicePtr(ElementType *ptr) {
+            m_device_ptr = ptr;
+          }
+
+          RAJA_INLINE
+          Kripke::ExecutionSpace getLastSpace() const {
+            return m_last_space;
+          }
+
+        private:
+          mutable ElementType *m_host_ptr = nullptr;
+          mutable ElementType *m_device_ptr = nullptr;
+          mutable Kripke::ExecutionSpace m_last_space = Kripke::CPU;
       };
 
       RAJA_INLINE
@@ -290,42 +325,40 @@ namespace Core {
 
       RAJA_INLINE
       void ensureHostCurrent(size_t chunk_id) const {
-        if(m_allocation_space != Kripke::GPU ||
-           m_chunk_to_data[chunk_id].device_ptr == nullptr ||
-           m_chunk_to_data[chunk_id].last_space == Kripke::CPU){
+        auto &chunk = m_chunk_to_data[chunk_id];
+        if(chunk.getDevicePtr() == nullptr ||
+           chunk.getLastSpace() == Kripke::CPU){
           return;
         }
 
-        if(m_chunk_to_data[chunk_id].host_ptr == nullptr){
-          m_chunk_to_data[chunk_id].host_ptr = allocateHostBuffer(
-              m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        if(chunk.getHostPtr() == nullptr){
+          chunk.setHostPtr(allocateHostBuffer(m_chunk_to_size[chunk_id]*sizeof(ElementType)));
         }
         synchronizeDevice();
-        MemoryManager::copy(m_chunk_to_data[chunk_id].host_ptr,
-                            m_chunk_to_data[chunk_id].device_ptr,
+        MemoryManager::copy(chunk.getHostPtr(),
+                            chunk.getDevicePtr(),
                             m_chunk_to_size[chunk_id]*sizeof(ElementType));
-        m_chunk_to_data[chunk_id].last_space = Kripke::CPU;
+        chunk.registerTouch(Kripke::CPU);
       }
 
       RAJA_INLINE
       void ensureDeviceCurrent(size_t chunk_id) const {
-        if(m_allocation_space != Kripke::GPU ||
-           m_chunk_to_data[chunk_id].last_space == Kripke::GPU){
+        auto &chunk = m_chunk_to_data[chunk_id];
+        if(chunk.getLastSpace() == Kripke::GPU){
           return;
         }
 
-        if(m_chunk_to_data[chunk_id].device_ptr == nullptr){
-          m_chunk_to_data[chunk_id].device_ptr = allocateDeviceBuffer(
-              m_chunk_to_size[chunk_id]*sizeof(ElementType));
+        if(chunk.getDevicePtr() == nullptr){
+          chunk.setDevicePtr(allocateDeviceBuffer(m_chunk_to_size[chunk_id]*sizeof(ElementType)));
         }
-        MemoryManager::copy(m_chunk_to_data[chunk_id].device_ptr,
-                            m_chunk_to_data[chunk_id].host_ptr,
+        MemoryManager::copy(chunk.getDevicePtr(),
+                            chunk.getHostPtr(),
                             m_chunk_to_size[chunk_id]*sizeof(ElementType));
-        m_chunk_to_data[chunk_id].last_space = Kripke::GPU;
+        chunk.registerTouch(Kripke::GPU);
       }
 
       RAJA_INLINE
-      void synchronizeDevice() const {
+      static void synchronizeDevice() {
 #if defined(KRIPKE_USE_CUDA)
         RAJA::synchronize<RAJA::cuda_synchronize>();
 #elif defined(KRIPKE_USE_HIP)
@@ -339,6 +372,7 @@ namespace Core {
       std::vector<size_t> m_chunk_to_size;
 #if defined(KRIPKE_USE_CHAI)
       std::vector<ElementPtr> m_chunk_to_data;
+      Kripke::ExecutionSpace m_allocation_space;
 #elif defined(KRIPKE_USE_UMPIRE)
       mutable std::vector<ChunkData> m_chunk_to_data;
       Kripke::ExecutionSpace m_allocation_space;
@@ -423,7 +457,16 @@ namespace Core {
       DefaultViewType getView(Kripke::SdomId sdom_id) const {
 
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
-        auto ptr = Parent::getHostData(sdom_id);
+
+#if defined(KRIPKE_USE_CHAI)
+        Parent::m_chunk_to_data[chunk_id].data(chai::CPU);
+        auto ptr = Parent::m_chunk_to_data[chunk_id];
+#elif defined(KRIPKE_USE_UMPIRE)
+        Parent::ensureHostCurrent(chunk_id);
+        auto ptr = Parent::m_chunk_to_data[chunk_id].getHostPtr();
+#else
+        auto ptr = Parent::m_chunk_to_data[chunk_id];
+#endif
         auto layout = m_chunk_to_layout[chunk_id];
 
         return DefaultViewType(ptr, layout);
@@ -436,12 +479,17 @@ namespace Core {
         size_t chunk_id = Parent::m_subdomain_to_chunk[*sdom_id];
         auto layout = m_chunk_to_layout[chunk_id];
 
-#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
         KRIPKE_ASSERT(Parent::m_allocation_space == Kripke::GPU,
             "getDeviceView requires a GPU-backed field");
-        auto ptr = Parent::getDeviceData(sdom_id);
-#elif defined(KRIPKE_USE_UMPIRE)
-        auto ptr = Parent::getHostData(sdom_id);
+        auto ptr = Parent::m_chunk_to_data[chunk_id].data(Kripke::GPU);
+#elif defined(KRIPKE_USE_CHAI)
+        auto ptr = Parent::m_chunk_to_data[chunk_id].data(Kripke::CPU);
+#elif defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+        KRIPKE_ASSERT(Parent::m_allocation_space == Kripke::GPU,
+            "getDeviceView requires a GPU-backed field");
+        Parent::ensureDeviceCurrent(chunk_id);
+        auto ptr = Parent::m_chunk_to_data[chunk_id].getDevicePtr();
 #else
         auto ptr = Parent::m_chunk_to_data[chunk_id];
 #endif
@@ -462,13 +510,20 @@ namespace Core {
 
         LType layout = RAJA::make_stride_one<LInfo::stride_one_dim>(m_chunk_to_layout[chunk_id]);
 
-#if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_UMPIRE)
-        if(Parent::m_allocation_space == Kripke::GPU){
-          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getDeviceData(sdom_id), layout);
+#if (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_CHAI)
+        if(Parent::m_allocation_space == chai::GPU){
+          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::GPU), layout);
         }
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
-#elif defined(KRIPKE_USE_UMPIRE)
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::getHostData(sdom_id), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+#elif defined(KRIPKE_USE_CHAI)
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].data(chai::CPU), layout);
+#elif (defined(KRIPKE_USE_HIP) || defined(KRIPKE_USE_CUDA)) && defined(KRIPKE_USE_UMPIRE)
+        if(Parent::m_allocation_space == Kripke::GPU){
+          Parent::ensureDeviceCurrent(chunk_id);
+          return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].getDevicePtr(), layout);
+        }
+        Parent::ensureHostCurrent(chunk_id);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::::m_chunk_to_data[chunk_id].getHostPtr(), layout);
 #else
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id], layout);
 #endif
@@ -488,10 +543,10 @@ namespace Core {
 
 #if defined(KRIPKE_USE_UMPIRE) && !defined(KRIPKE_USE_CHAI)
         printf("  m_chunk_to_data(host): ");
-        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.host_ptr);}
+        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.getHostPtr());}
         printf("\n");
         printf("  m_chunk_to_data(device): ");
-        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.device_ptr);}
+        for(auto const &x : Parent::m_chunk_to_data){printf("%p ", (void*)x.getDevicePtr());}
         printf("\n");
 #else
         printf("  m_chunk_to_data: ");

--- a/src/Kripke/Core/Field.h
+++ b/src/Kripke/Core/Field.h
@@ -523,7 +523,7 @@ namespace Core {
           return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].getDevicePtr(), layout);
         }
         Parent::ensureHostCurrent(chunk_id);
-        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::::m_chunk_to_data[chunk_id].getHostPtr(), layout);
+        return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id].getHostPtr(), layout);
 #else
         return ViewType<Order, ElementType, ElementType *, IDX_TYPES...>(Parent::m_chunk_to_data[chunk_id], layout);
 #endif

--- a/src/Kripke/Core/MemoryManager.cpp
+++ b/src/Kripke/Core/MemoryManager.cpp
@@ -12,7 +12,6 @@
 #define DEBUG
 #include <umpire/Umpire.hpp>
 #include <umpire/strategy/QuickPool.hpp>
-#include <chai/ManagedArray.hpp>
 #undef DEBUG
 #endif
 
@@ -26,12 +25,10 @@ MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_poo
   size_t umpire_device_pool_size = ((size_t) device_pool_size) * 1024 * 1024 * 1024;
   size_t umpire_dev_block_size = 512;
   auto device_pool_allocator = rm.makeAllocator<umpire::strategy::QuickPool>(allocator_name, rm.getAllocator("DEVICE"), umpire_device_pool_size, umpire_dev_block_size);
-  auto chai_resource_manager = chai::ArrayManager::getInstance();
-  chai_resource_manager->setAllocator(chai::GPU, device_pool_allocator);
-  // force allocation of GPU memory pool
-  auto tmp = new chai::ManagedArray<int>(100, chai::GPU);
-  tmp->free(chai::GPU);
-  delete tmp;
+
+  // Force the pool to materialize during initialization instead of on first use.
+  void *tmp = device_pool_allocator.allocate(100*sizeof(int));
+  device_pool_allocator.deallocate(tmp);
 #endif // KRIPKE_USE_CHAI
 }
 
@@ -45,10 +42,30 @@ double MemoryManager::getDeviceMemoryPoolSize() {
 
 double MemoryManager::getDeviceMemoryHighWatermark() {
 #ifdef KRIPKE_USE_CHAI
-  auto chai_resource_manager = chai::ArrayManager::getInstance();
-  auto device_allocator = chai_resource_manager->getAllocator(chai::GPU);
+  auto device_allocator = getDeviceAllocator();
   return ((double) device_allocator.getHighWatermark()) / (1024 * 1024 * 1024);
 #else
   return 0.0;
 #endif
 }
+
+#ifdef KRIPKE_USE_CHAI
+umpire::Allocator MemoryManager::getHostAllocator() {
+  auto &rm = umpire::ResourceManager::getInstance();
+  return rm.getAllocator("HOST");
+}
+
+umpire::Allocator MemoryManager::getDeviceAllocator() {
+  auto &rm = umpire::ResourceManager::getInstance();
+  return rm.getAllocator("KRIPKE_DEVICE_POOL");
+}
+
+void MemoryManager::copy(void *dst, void const *src, size_t bytes) {
+  if(bytes == 0){
+    return;
+  }
+
+  auto &rm = umpire::ResourceManager::getInstance();
+  rm.copy(dst, src, bytes);
+}
+#endif

--- a/src/Kripke/Core/MemoryManager.cpp
+++ b/src/Kripke/Core/MemoryManager.cpp
@@ -66,6 +66,6 @@ void MemoryManager::copy(void *dst, void const *src, size_t bytes) {
   }
 
   auto &rm = umpire::ResourceManager::getInstance();
-  rm.copy(dst, src, bytes);
+  rm.copy(dst, const_cast<void *>(src), bytes);
 }
 #endif

--- a/src/Kripke/Core/MemoryManager.cpp
+++ b/src/Kripke/Core/MemoryManager.cpp
@@ -12,7 +12,7 @@ using namespace Kripke;
 using namespace Kripke::Core;
 
 MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_pool_size) {
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
   auto &rm = umpire::ResourceManager::getInstance();
   const char * allocator_name = "KRIPKE_DEVICE_POOL";
   size_t umpire_device_pool_size = ((size_t) device_pool_size) * 1024 * 1024 * 1024;
@@ -21,16 +21,16 @@ MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_poo
   // Force allocation of GPU memory pool
   void *tmp = device_pool_allocator.allocate(100*sizeof(int));
   device_pool_allocator.deallocate(tmp);
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
   // Set CHAI device memory pool allocator
   auto chai_resource_manager = chai::ArrayManager::getInstance();
-  chai_resource_manager->setAllocator(chai::GPU, device_pool_allocator);
+  chai_resource_manager->setAllocator(Kripke::GPU, device_pool_allocator);
 #endif // KRIPKE_USE_CHAI
 #endif // KRIPKE_USE_UMPIRE
 }
 
 double MemoryManager::getDeviceMemoryPoolSize() {
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
   return (double) device_pool_size;
 #else
       return 0.0;
@@ -38,7 +38,7 @@ double MemoryManager::getDeviceMemoryPoolSize() {
 }
 
 double MemoryManager::getDeviceMemoryHighWatermark() {
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
   auto device_allocator = getDeviceAllocator();
   return ((double) device_allocator.getHighWatermark()) / (1024 * 1024 * 1024);
 #else
@@ -46,7 +46,7 @@ double MemoryManager::getDeviceMemoryHighWatermark() {
 #endif
 }
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
 umpire::Allocator MemoryManager::getHostAllocator() {
   auto &rm = umpire::ResourceManager::getInstance();
   return rm.getAllocator("HOST");

--- a/src/Kripke/Core/MemoryManager.cpp
+++ b/src/Kripke/Core/MemoryManager.cpp
@@ -12,7 +12,7 @@ using namespace Kripke;
 using namespace Kripke::Core;
 
 MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_pool_size) {
-#if defined(KRIPKE_USE_UMPIRE)
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   auto &rm = umpire::ResourceManager::getInstance();
   const char * allocator_name = "KRIPKE_DEVICE_POOL";
   size_t umpire_device_pool_size = ((size_t) device_pool_size) * 1024 * 1024 * 1024;
@@ -30,7 +30,7 @@ MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_poo
 }
 
 double MemoryManager::getDeviceMemoryPoolSize() {
-#if defined(KRIPKE_USE_UMPIRE)
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   return (double) device_pool_size;
 #else
       return 0.0;
@@ -38,7 +38,7 @@ double MemoryManager::getDeviceMemoryPoolSize() {
 }
 
 double MemoryManager::getDeviceMemoryHighWatermark() {
-#if defined(KRIPKE_USE_UMPIRE)
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   auto device_allocator = getDeviceAllocator();
   return ((double) device_allocator.getHighWatermark()) / (1024 * 1024 * 1024);
 #else

--- a/src/Kripke/Core/MemoryManager.cpp
+++ b/src/Kripke/Core/MemoryManager.cpp
@@ -8,32 +8,29 @@
 #include <Kripke.h>
 #include <Kripke/Core/MemoryManager.h>
 
-#ifdef KRIPKE_USE_CHAI
-#define DEBUG
-#include <umpire/Umpire.hpp>
-#include <umpire/strategy/QuickPool.hpp>
-#undef DEBUG
-#endif
-
 using namespace Kripke;
 using namespace Kripke::Core;
 
 MemoryManager::MemoryManager(int device_pool_size) : device_pool_size(device_pool_size) {
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
   auto &rm = umpire::ResourceManager::getInstance();
   const char * allocator_name = "KRIPKE_DEVICE_POOL";
   size_t umpire_device_pool_size = ((size_t) device_pool_size) * 1024 * 1024 * 1024;
   size_t umpire_dev_block_size = 512;
   auto device_pool_allocator = rm.makeAllocator<umpire::strategy::QuickPool>(allocator_name, rm.getAllocator("DEVICE"), umpire_device_pool_size, umpire_dev_block_size);
-
-  // Force the pool to materialize during initialization instead of on first use.
+  // Force allocation of GPU memory pool
   void *tmp = device_pool_allocator.allocate(100*sizeof(int));
   device_pool_allocator.deallocate(tmp);
+#ifdef KRIPKE_USE_CHAI
+  // Set CHAI device memory pool allocator
+  auto chai_resource_manager = chai::ArrayManager::getInstance();
+  chai_resource_manager->setAllocator(chai::GPU, device_pool_allocator);
 #endif // KRIPKE_USE_CHAI
+#endif // KRIPKE_USE_UMPIRE
 }
 
 double MemoryManager::getDeviceMemoryPoolSize() {
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
   return (double) device_pool_size;
 #else
       return 0.0;
@@ -41,7 +38,7 @@ double MemoryManager::getDeviceMemoryPoolSize() {
 }
 
 double MemoryManager::getDeviceMemoryHighWatermark() {
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
   auto device_allocator = getDeviceAllocator();
   return ((double) device_allocator.getHighWatermark()) / (1024 * 1024 * 1024);
 #else
@@ -49,7 +46,7 @@ double MemoryManager::getDeviceMemoryHighWatermark() {
 #endif
 }
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
 umpire::Allocator MemoryManager::getHostAllocator() {
   auto &rm = umpire::ResourceManager::getInstance();
   return rm.getAllocator("HOST");

--- a/src/Kripke/Core/MemoryManager.h
+++ b/src/Kripke/Core/MemoryManager.h
@@ -10,7 +10,7 @@
 
 #include <Kripke.h>
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
 #include <umpire/Umpire.hpp>
 #endif
 
@@ -26,7 +26,7 @@ class MemoryManager {
     double getDeviceMemoryPoolSize();
     double getDeviceMemoryHighWatermark();
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
     static umpire::Allocator getHostAllocator();
     static umpire::Allocator getDeviceAllocator();
     static void copy(void *dst, void const *src, size_t bytes);

--- a/src/Kripke/Core/MemoryManager.h
+++ b/src/Kripke/Core/MemoryManager.h
@@ -10,6 +10,10 @@
 
 #include <Kripke.h>
 
+#ifdef KRIPKE_USE_CHAI
+#include <umpire/Umpire.hpp>
+#endif
+
 namespace Kripke {
 namespace Core {
 
@@ -21,6 +25,12 @@ class MemoryManager {
     MemoryManager(int device_pool_size);
     double getDeviceMemoryPoolSize();
     double getDeviceMemoryHighWatermark();
+
+#ifdef KRIPKE_USE_CHAI
+    static umpire::Allocator getHostAllocator();
+    static umpire::Allocator getDeviceAllocator();
+    static void copy(void *dst, void const *src, size_t bytes);
+#endif
 };
 
 } } // namespace

--- a/src/Kripke/Core/MemoryManager.h
+++ b/src/Kripke/Core/MemoryManager.h
@@ -10,10 +10,6 @@
 
 #include <Kripke.h>
 
-#ifdef KRIPKE_USE_UMPIRE
-#include <umpire/Umpire.hpp>
-#endif
-
 namespace Kripke {
 namespace Core {
 
@@ -26,7 +22,7 @@ class MemoryManager {
     double getDeviceMemoryPoolSize();
     double getDeviceMemoryHighWatermark();
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
     static umpire::Allocator getHostAllocator();
     static umpire::Allocator getDeviceAllocator();
     static void copy(void *dst, void const *src, size_t bytes);

--- a/src/Kripke/Generate/Data.cpp
+++ b/src/Kripke/Generate/Data.cpp
@@ -89,7 +89,7 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
     int global_num_groups = global_group_set.size(sdom_id);
 
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-    if(field_sigs.getAllocationSpace() == chai::GPU){
+    if(field_sigs.getAllocationSpace() == Kripke::GPU){
       auto sigs = field_sigs.getDeviceView(sdom_id);
       double sigs0 = input_vars.sigs[0];
       double sigs1 = input_vars.sigs[1];

--- a/src/Kripke/Generate/Data.cpp
+++ b/src/Kripke/Generate/Data.cpp
@@ -88,7 +88,7 @@ void Kripke::Generate::generateData(Kripke::Core::DataStore &data_store,
 
     int global_num_groups = global_group_set.size(sdom_id);
 
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
     if(field_sigs.getAllocationSpace() == Kripke::GPU){
       auto sigs = field_sigs.getDeviceView(sdom_id);
       double sigs0 = input_vars.sigs[0];

--- a/src/Kripke/Generate/Space.cpp
+++ b/src/Kripke/Generate/Space.cpp
@@ -345,7 +345,7 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
     int num_mixelem = set_mixelem.size(sdom_id);
 
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-    if(field_sigt.getAllocationSpace() == chai::GPU){
+    if(field_sigt.getAllocationSpace() == Kripke::GPU){
       auto mixelem_to_material = field_mixed_to_material.getDeviceView(sdom_id);
       auto mixelem_to_fraction = field_mixed_to_fraction.getDeviceView(sdom_id);
       auto zone_to_num_mixelem = field_zone_to_num_mixelem.getDeviceView(sdom_id);

--- a/src/Kripke/Generate/Space.cpp
+++ b/src/Kripke/Generate/Space.cpp
@@ -344,7 +344,7 @@ void Kripke::Generate::generateSpace(Kripke::Core::DataStore &data_store,
     int num_zones = set_zone_linear.size(sdom_id);
     int num_mixelem = set_mixelem.size(sdom_id);
 
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
     if(field_sigt.getAllocationSpace() == Kripke::GPU){
       auto mixelem_to_material = field_mixed_to_material.getDeviceView(sdom_id);
       auto mixelem_to_fraction = field_mixed_to_fraction.getDeviceView(sdom_id);

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -13,10 +13,6 @@
 #include <Kripke/Core/DataStore.h>
 #include <utility>
 
-#ifdef KRIPKE_USE_CHAI
-#include <chai/ExecutionSpaces.hpp>
-#endif
-
 namespace Kripke {
 
   namespace Kernel {
@@ -27,7 +23,7 @@ namespace Kripke {
       RAJA_INLINE
       bool fieldUsesDevice(FieldType const &field){
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-        return field.getAllocationSpace() == chai::GPU;
+        return field.getAllocationSpace() == Kripke::GPU;
 #else
         (void)field;
         return false;

--- a/src/Kripke/Kernel.h
+++ b/src/Kripke/Kernel.h
@@ -22,7 +22,7 @@ namespace Kripke {
       template<typename FieldType>
       RAJA_INLINE
       bool fieldUsesDevice(FieldType const &field){
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
         return field.getAllocationSpace() == Kripke::GPU;
 #else
         (void)field;

--- a/src/Kripke/ParallelComm.cpp
+++ b/src/Kripke/ParallelComm.cpp
@@ -323,16 +323,12 @@ void ParallelComm::testRecieves(void){
       // get subdomain that this completed for
       int sdom_id = recv_subdomains[index];
 
-#if defined(KRIPKE_USE_CHAI)
+#if defined(KRIPKE_USE_UMPIRE)
       // Performance experiment: skip CHAI device-touch bookkeeping after
       // GPU-aware MPI writes directly into plane data.
       // if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
       //   m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
       // }
-#elif defined(KRIPKE_USE_UMPIRE)
-      if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
-        m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
-      }
 #endif
 
       // remove the request from the list

--- a/src/Kripke/ParallelComm.cpp
+++ b/src/Kripke/ParallelComm.cpp
@@ -19,7 +19,7 @@ namespace {
 
 bool fieldIsGpuBacked(Kripke::Core::FieldStorage<double> &field)
 {
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   return field.getAllocationSpace() == Kripke::GPU;
 #else
   (void)field;
@@ -29,7 +29,7 @@ bool fieldIsGpuBacked(Kripke::Core::FieldStorage<double> &field)
 
 bool useGpuAwareMPI(Kripke::Core::FieldStorage<double> &field)
 {
-#if defined(KRIPKE_USE_GPU_AWARE_MPI) && defined(KRIPKE_USE_CHAI) && \
+#if defined(KRIPKE_USE_GPU_AWARE_MPI) && defined(KRIPKE_USE_UMPIRE) && \
     (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   return fieldIsGpuBacked(field);
 #else
@@ -59,7 +59,7 @@ static void copyPlane(Kripke::Core::FieldStorage<double> &dst_plane,
   KRIPKE_ASSERT(dst_plane.size(dst_sdom_id) == (size_t)num_elem,
       "Cannot copy plane data with different subdomain sizes");
 
-#if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
   if(dst_plane.getAllocationSpace() == Kripke::GPU &&
      src_plane.getAllocationSpace() == Kripke::GPU){
     double *dst = dst_plane.getDeviceData(dst_sdom_id);
@@ -80,7 +80,7 @@ static void copyPlane(Kripke::Core::FieldStorage<double> &dst_plane,
     });
     return;
   }
-#endif  // #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
+#endif  // #if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
 
   double *dst = dst_plane.getHostData(dst_sdom_id);
   double const *src = src_plane.getHostDataConst(src_sdom_id);
@@ -324,9 +324,17 @@ void ParallelComm::testRecieves(void){
       int sdom_id = recv_subdomains[index];
 
 #ifdef KRIPKE_USE_CHAI
+      // Performance experiment: skip CHAI device-touch bookkeeping after
+      // GPU-aware MPI writes directly into plane data.
+      // if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
+      //   m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
+      // }
+#else
+#if KRIPKE_USE_UMPIRE
       if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
         m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
       }
+#endif
 #endif
 
       // remove the request from the list

--- a/src/Kripke/ParallelComm.cpp
+++ b/src/Kripke/ParallelComm.cpp
@@ -20,7 +20,7 @@ namespace {
 bool fieldIsGpuBacked(Kripke::Core::FieldStorage<double> &field)
 {
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-  return field.getAllocationSpace() == chai::GPU;
+  return field.getAllocationSpace() == Kripke::GPU;
 #else
   (void)field;
   return false;
@@ -60,8 +60,8 @@ static void copyPlane(Kripke::Core::FieldStorage<double> &dst_plane,
       "Cannot copy plane data with different subdomain sizes");
 
 #if defined(KRIPKE_USE_CHAI) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
-  if(dst_plane.getAllocationSpace() == chai::GPU &&
-     src_plane.getAllocationSpace() == chai::GPU){
+  if(dst_plane.getAllocationSpace() == Kripke::GPU &&
+     src_plane.getAllocationSpace() == Kripke::GPU){
     double *dst = dst_plane.getDeviceData(dst_sdom_id);
     double *src = src_plane.getDeviceData(src_sdom_id);
   //for(int i = 0;i < num_elem;++ i){
@@ -324,11 +324,9 @@ void ParallelComm::testRecieves(void){
       int sdom_id = recv_subdomains[index];
 
 #ifdef KRIPKE_USE_CHAI
-      // Performance experiment: skip CHAI device-touch bookkeeping after
-      // GPU-aware MPI writes directly into plane data.
-      // if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
-      //   m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
-      // }
+      if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
+        m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
+      }
 #endif
 
       // remove the request from the list

--- a/src/Kripke/ParallelComm.cpp
+++ b/src/Kripke/ParallelComm.cpp
@@ -323,18 +323,16 @@ void ParallelComm::testRecieves(void){
       // get subdomain that this completed for
       int sdom_id = recv_subdomains[index];
 
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
       // Performance experiment: skip CHAI device-touch bookkeeping after
       // GPU-aware MPI writes directly into plane data.
       // if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
       //   m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
       // }
-#else
-#if KRIPKE_USE_UMPIRE
+#elif defined(KRIPKE_USE_UMPIRE)
       if(useGpuAwareMPI(*m_plane_data[recv_dimensions[index]])){
         m_plane_data[recv_dimensions[index]]->registerDeviceTouch(SdomId{sdom_id});
       }
-#endif
 #endif
 
       // remove the request from the list

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -135,7 +135,7 @@ namespace Kripke {
     return SdomAL<AL>{sdom_id};
   }
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
   RAJA_INLINE
   bool archUsesDevice(ArchV arch_v)
   {
@@ -156,7 +156,7 @@ namespace Kripke {
   RAJA_INLINE
   Kripke::ExecutionSpace fieldAllocationSpace(ArchV arch_v)
   {
-    if(archUsesDevice(arch_v) && !FieldType::host_resident_normal_chai_gpu){
+    if(archUsesDevice(arch_v) && !FieldType::host_resident_normal_gpu){
       return Kripke::GPU;
     }
     return Kripke::CPU;
@@ -172,7 +172,7 @@ namespace Kripke {
     dispatchLayout(al_v.layout_v, [&](auto layout_t){
       using order_t = typename DefaultOrder<decltype(layout_t)>::type; 
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
       field = new FieldType(set, fieldAllocationSpace<FieldType>(al_v.arch_v), order_t{});
 #else
       field = new FieldType(set, order_t{});

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -154,12 +154,12 @@ namespace Kripke {
 
   template<typename FieldType>
   RAJA_INLINE
-  chai::ExecutionSpace fieldAllocationSpace(ArchV arch_v)
+  Kripke::ExecutionSpace fieldAllocationSpace(ArchV arch_v)
   {
     if(archUsesDevice(arch_v) && !FieldType::host_resident_normal_chai_gpu){
-      return chai::GPU;
+      return Kripke::GPU;
     }
-    return chai::CPU;
+    return Kripke::CPU;
   }
 #endif
 

--- a/src/Kripke/VarTypes.h
+++ b/src/Kripke/VarTypes.h
@@ -135,7 +135,7 @@ namespace Kripke {
     return SdomAL<AL>{sdom_id};
   }
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
   RAJA_INLINE
   bool archUsesDevice(ArchV arch_v)
   {
@@ -172,7 +172,7 @@ namespace Kripke {
     dispatchLayout(al_v.layout_v, [&](auto layout_t){
       using order_t = typename DefaultOrder<decltype(layout_t)>::type; 
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
       field = new FieldType(set, fieldAllocationSpace<FieldType>(al_v.arch_v), order_t{});
 #else
       field = new FieldType(set, order_t{});

--- a/src/KripkeConfig.h.in
+++ b/src/KripkeConfig.h.in
@@ -11,6 +11,7 @@
 #cmakedefine KRIPKE_USE_OPENMP
 #cmakedefine KRIPKE_USE_CUDA
 #cmakedefine KRIPKE_USE_CHAI
+#cmakedefine KRIPKE_USE_UMPIRE
 #cmakedefine KRIPKE_USE_GPU_AWARE_MPI
 #cmakedefine KRIPKE_USE_HIP
 

--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -224,8 +224,14 @@ int main(int argc, char **argv) {
 
 #ifdef KRIPKE_USE_CHAI
     printf("  CHAI Enabled:           Yes\n");
+    printf("  Umpire Enabled:         Yes\n");
 #else
     printf("  CHAI Enabled:           No\n");
+#ifdef KRIPKE_USE_UMPIRE
+    printf("  Umpire Enabled:         Yes\n");
+#else
+    printf("  Umpire Enabled:         No\n");
+#endif
 #endif
 
 #ifdef KRIPKE_USE_CUDA
@@ -539,7 +545,7 @@ int main(int argc, char **argv) {
     printf("  Sweep efficiency :  %4.5lf [100.0 * SweepSubdomain time / SweepSolver time]\n", sweep_eff);
     printf("  Number of unknowns: %lu\n", (unsigned long) num_unknowns);
 
-#ifdef KRIPKE_USE_CHAI
+#ifdef KRIPKE_USE_UMPIRE
     double device_memory_pool_size = memory_manager.getDeviceMemoryPoolSize();
     double device_memory_high_watermark = memory_manager.getDeviceMemoryHighWatermark();
 #ifdef KRIPKE_USE_CALIPER

--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -545,7 +545,7 @@ int main(int argc, char **argv) {
     printf("  Sweep efficiency :  %4.5lf [100.0 * SweepSubdomain time / SweepSolver time]\n", sweep_eff);
     printf("  Number of unknowns: %lu\n", (unsigned long) num_unknowns);
 
-#if defined(KRIPKE_USE_UMPIRE)
+#if defined(KRIPKE_USE_UMPIRE) && (defined(KRIPKE_USE_CUDA) || defined(KRIPKE_USE_HIP))
     double device_memory_pool_size = memory_manager.getDeviceMemoryPoolSize();
     double device_memory_high_watermark = memory_manager.getDeviceMemoryHighWatermark();
 #ifdef KRIPKE_USE_CALIPER

--- a/src/kripke.cpp
+++ b/src/kripke.cpp
@@ -222,12 +222,12 @@ int main(int argc, char **argv) {
     printf("  Compiler Flags:         \"%s\"\n", KRIPKE_CXX_FLAGS);
     printf("  Linker Flags:           \"%s\"\n", KRIPKE_LINK_FLAGS);
 
-#ifdef KRIPKE_USE_CHAI
+#if defined(KRIPKE_USE_CHAI)
     printf("  CHAI Enabled:           Yes\n");
     printf("  Umpire Enabled:         Yes\n");
 #else
     printf("  CHAI Enabled:           No\n");
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
     printf("  Umpire Enabled:         Yes\n");
 #else
     printf("  Umpire Enabled:         No\n");
@@ -545,7 +545,7 @@ int main(int argc, char **argv) {
     printf("  Sweep efficiency :  %4.5lf [100.0 * SweepSubdomain time / SweepSolver time]\n", sweep_eff);
     printf("  Number of unknowns: %lu\n", (unsigned long) num_unknowns);
 
-#ifdef KRIPKE_USE_UMPIRE
+#if defined(KRIPKE_USE_UMPIRE)
     double device_memory_pool_size = memory_manager.getDeviceMemoryPoolSize();
     double device_memory_high_watermark = memory_manager.getDeviceMemoryHighWatermark();
 #ifdef KRIPKE_USE_CALIPER


### PR DESCRIPTION
This PR adds an Umpire-only build to Kripke
1. If `ENABLE_CHAI=ON`, then the code builds as before using both CHAI and Umpire.
2. If `ENABLE_CHAI=OFF`, but either `ENABLE_CUDA=ON` or `ENABLE_HIP=ON`, i.e. for a GPU build, the code builds an Umpire-only version with a device pool. It is important to note that an Umpire-backed CPU build is only possible when using CHAI (as before). A standalone CPU-only Umpire-only build is NOT supported
3. When `ENABLE_CHAI=ON`, the cmake config enables two pragma definitions `KRIPKE_USE_CHAI` and `KRIPKE_USE_UMPIRE`
4. When `ENABLE_CHAI=OFF`, but either `ENABLE_CUDA=ON` or `ENABLE_HIP=ON`, the cmake config enables only `KRIPKE_USE_UMPIRE`
5. The logic to manage the memory HtoD or DtoH memory transfers is implemented in the file `Field.h`. As with CHAI, the Umpire-only allocation only allocates storage for an execution space if the code actually touches the data on that space.